### PR TITLE
make resolving cursor positions more efficient

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from "react";
 
 import { EditorView } from "@codemirror/view";
 import { CommentsSidebar } from "./CommentsSidebar";
+import { useThreadsWithPositions } from "../utils";
 
 function App({ docUrl }: { docUrl: AutomergeUrl }) {
   const [doc, changeDoc] = useDocument<MarkdownDoc>(docUrl); // used to trigger re-rendering when the doc loads
@@ -34,6 +35,12 @@ function App({ docUrl }: { docUrl: AutomergeUrl }) {
     setSessionInMemory(session);
   };
 
+  const threadsWithPositions = useThreadsWithPositions({
+    doc,
+    view,
+    activeThreadId,
+  });
+
   if (!doc || !session) {
     return <LoadingScreen docUrl={docUrl} handle={handle} />;
   }
@@ -57,19 +64,19 @@ function App({ docUrl }: { docUrl: AutomergeUrl }) {
             path={["content"]}
             setSelection={setSelection}
             setView={setView}
-            activeThreadId={activeThreadId}
+            threadsWithPositions={threadsWithPositions}
             setActiveThreadId={setActiveThreadId}
           />
         </div>
         <div className="flex-grow bg-gray-50">
           <CommentsSidebar
-            view={view}
             session={session}
             doc={doc}
             changeDoc={changeDoc}
             selection={selection}
             activeThreadId={activeThreadId}
             setActiveThreadId={setActiveThreadId}
+            threadsWithPositions={threadsWithPositions}
           />
         </div>
       </div>

--- a/src/components/CommentsSidebar.tsx
+++ b/src/components/CommentsSidebar.tsx
@@ -1,5 +1,11 @@
 import { Button } from "@/components/ui/button";
-import { Comment, CommentThread, LocalSession, MarkdownDoc } from "../schema";
+import {
+  Comment,
+  CommentThread,
+  CommentThreadWithPosition,
+  LocalSession,
+  MarkdownDoc,
+} from "../schema";
 
 import { Check, MessageSquarePlus, Reply } from "lucide-react";
 import { Textarea } from "@/components/ui/textarea";
@@ -12,29 +18,23 @@ import {
   PopoverClose,
 } from "@/components/ui/popover";
 import { TextSelection } from "./MarkdownEditor";
-import { EditorView } from "@codemirror/view";
 import { useEffect, useState } from "react";
-import {
-  useScrollPosition,
-  getVisibleTheadsWithPos,
-  getRelativeTimeString,
-  cmRangeToAMRange,
-} from "../utils";
+import { getRelativeTimeString, cmRangeToAMRange } from "../utils";
 
 export const CommentsSidebar = ({
   doc,
   changeDoc,
   selection,
-  view,
   session,
+  threadsWithPositions,
   activeThreadId,
   setActiveThreadId,
 }: {
   doc: MarkdownDoc;
   changeDoc: (changeFn: ChangeFn<MarkdownDoc>) => void;
   selection: TextSelection;
-  view: EditorView | undefined;
   session: LocalSession;
+  threadsWithPositions: CommentThreadWithPosition[];
   activeThreadId: string | null;
   setActiveThreadId: (threadId: string | null) => void;
 }) => {
@@ -49,18 +49,6 @@ export const CommentsSidebar = ({
   useEffect(() => {
     setSuppressButton(false);
   }, [selection?.from, selection?.to]);
-
-  // It may be inefficient to rerender comments sidebar on each scroll but
-  // it's fine for now and it lets us reposition comments as the user scrolls.
-  // (Notably we're not literally repositioning comments in JS;
-  // we just use CodeMirror to compute position, and it doesn't tell us position
-  // of comments that are way off-screen. That's why we need this scroll handler
-  // to catch when things come near the screen)
-  useScrollPosition();
-
-  const threadsWithPositions = view
-    ? getVisibleTheadsWithPos(doc, view, activeThreadId)
-    : [];
 
   const startCommentThreadAtSelection = (commentText: string) => {
     if (!selection) return;
@@ -139,7 +127,9 @@ export const CommentsSidebar = ({
                     {getRelativeTimeString(comment.timestamp)}
                   </span>
                 </div>
-                <div className="cursor-default text-sm whitespace-pre-wrap">{comment.content}</div>
+                <div className="cursor-default text-sm whitespace-pre-wrap">
+                  {comment.content}
+                </div>
               </div>
             ))}
           </div>

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -19,6 +19,8 @@ export type CommentThreadForUI = CommentThread & {
   active: boolean;
 };
 
+export type CommentThreadWithPosition = CommentThreadForUI & { yCoord: number };
+
 export type User = {
   id: string;
   name: string;


### PR DESCRIPTION
Previously we were turning all comment thread cursors on the doc into integer positions 6x per keystroke.

Now we only do that process 1x per keystroke, and we also skip it for resolved (aka hidden) comment threads, saving a lot of work.