### PR TITLE
fix copy / show account token button to not close modal

### DIFF
--- a/src/components/generic/AccountPicker.tsx
+++ b/src/components/generic/AccountPicker.tsx
@@ -268,13 +268,18 @@ export const AccountPicker = () => {
                   autoComplete="off"
                 />
 
-                <Button variant="ghost" onClick={onToggleShowAccountUrl}>
+                <Button
+                  variant="ghost"
+                  onClick={onToggleShowAccountUrl}
+                  type="button"
+                >
                   {showAccountUrl ? <Eye /> : <EyeOff />}
                 </Button>
 
                 <TooltipProvider>
                   <Tooltip open={isCopyTooltipOpen}>
                     <TooltipTrigger
+                      type="button"
                       onClick={onCopy}
                       onBlur={() => setIsCopyTooltipOpen(false)}
                     >


### PR DESCRIPTION
Set explicitly type to "button" so they don't submit the form in which they are contained