### PR TITLE
Group changes from a merged branch under the merge 

### DIFF
--- a/src/bots/essayEditorBot.ts
+++ b/src/bots/essayEditorBot.ts
@@ -64,9 +64,6 @@ ${JSON.stringify(functionsSpec)}
   ${targetDocHandle.docSync().content}
   `;
 
-  console.log(systemPrompt);
-  console.log(message);
-
   const response = await openaiClient.chat.completions.create({
     model: DEFAULT_MODEL,
     temperature: 0,
@@ -89,7 +86,6 @@ ${JSON.stringify(functionsSpec)}
 
   try {
     const parsed: any = JSON.parse(output.function_call.arguments);
-    console.log("parsed", parsed);
 
     const branchHandle = createBranch({
       name: `Edits by ${contactDoc.name}`,

--- a/src/patchwork/branches.ts
+++ b/src/patchwork/branches.ts
@@ -185,7 +185,6 @@ export const getChangesFromMergedBranch = ({
     fromHeads: baseHeads,
     toHeads: branchHeads,
   });
-  console.log({ changesInMain, changesInBranch });
 
   return new Set([...changesInBranch].filter((x) => !changesInMain.has(x)));
 };

--- a/src/patchwork/components/ConfigurableHistoryLog.tsx
+++ b/src/patchwork/components/ConfigurableHistoryLog.tsx
@@ -7,9 +7,9 @@ import {
   ChangeGroup,
   GROUPINGS_THAT_TAKE_BATCH_SIZE,
   GROUPINGS_THAT_TAKE_GAP_TIME,
-  charsAddedAndDeletedByPatches,
   getGroupedChanges,
 } from "../groupChanges";
+import { charsAddedAndDeletedByPatches } from "@/tee/statsForChangeGroup";
 import { GROUPINGS } from "../groupChanges";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Slider } from "@/components/ui/slider";

--- a/src/patchwork/components/Demo4/Demo4.tsx
+++ b/src/patchwork/components/Demo4/Demo4.tsx
@@ -102,7 +102,7 @@ export const Demo4: React.FC<{
   }, [selectedBranch]);
 
   const [isHistorySidebarOpen, setIsHistorySidebarOpen] =
-    useState<boolean>(false);
+    useState<boolean>(true);
 
   useEffect(() => {
     if (!isHistorySidebarOpen) {

--- a/src/patchwork/components/Demo4/Demo4.tsx
+++ b/src/patchwork/components/Demo4/Demo4.tsx
@@ -638,7 +638,6 @@ export const Demo4: React.FC<{
                   zoomLevel={historyZoomLevel}
                   textSelection={textSelection}
                   onClearTextSelection={() => {
-                    console.log("clear text selection");
                     setTextSelection({ from: 0, to: 0, yCoord: 0 });
                   }}
                 />

--- a/src/patchwork/components/Demo4/ReviewSidebar.tsx
+++ b/src/patchwork/components/Demo4/ReviewSidebar.tsx
@@ -124,8 +124,6 @@ export const ReviewSidebar: React.FC<{
     };
   }, [doc, markers, zoomLevel]);
 
-  console.log("THE GROUPS", groupedChanges);
-
   /** If there's a marker that specifies "hide history before this", we
    *  collapse change groups before that point by default.
    */

--- a/src/patchwork/components/Demo4/ReviewSidebar.tsx
+++ b/src/patchwork/components/Demo4/ReviewSidebar.tsx
@@ -463,10 +463,12 @@ export const ReviewSidebar: React.FC<{
                           </div>
                         )}
 
-                      <EditSummary
-                        changeGroup={changeGroup}
-                        selected={selected}
-                      />
+                      <div className="ml-[16px]">
+                        <EditSummary
+                          changeGroup={changeGroup}
+                          selected={selected}
+                        />
+                      </div>
                     </div>
                   )}
                   {changeGroup.markers.map((marker) => (
@@ -653,7 +655,7 @@ const EditSummary = ({
 }) => {
   return (
     <div
-      className={`group cursor-pointer  p-1 rounded-full font-bold flex ml-[16px] ${
+      className={`group cursor-pointer  p-1 rounded-full font-bold flex ${
         selected ? "bg-blue-100 bg-opacity-50" : "bg-transparent"
       } `}
     >
@@ -745,7 +747,8 @@ const MergedBranchView: React.FC<{
           </div>
         </ItemContent>
       </ItemView>
-      <div className="pl-6 mt-1">
+      <div className="mt-1 flex gap-1">
+        <div className="ml-8 w-3 h-3 border-b-2 border-l-2 border-gray-300 rounded-bl-full"></div>
         <EditSummary changeGroup={changeGroup} selected={selected} />
       </div>
     </div>

--- a/src/patchwork/components/MinimapWithDiff.tsx
+++ b/src/patchwork/components/MinimapWithDiff.tsx
@@ -1,7 +1,7 @@
 import { MarkdownDoc } from "@/tee/schema";
 import { Patch } from "@automerge/automerge/next";
 import { truncate } from "lodash";
-import { Heading, extractHeadings } from "../groupChanges";
+import { Heading, extractHeadings } from "@/tee/statsForChangeGroup";
 import { TextPatch } from "../utils";
 
 function patchOverlapsLine(start: number, end: number, patch: Patch): boolean {

--- a/src/patchwork/groupChanges.ts
+++ b/src/patchwork/groupChanges.ts
@@ -36,7 +36,7 @@ import {
   ChangeMetadata,
   DocHandle,
 } from "@automerge/automerge-repo/dist/DocHandle";
-import { Change, Hash, Heads } from "@automerge/automerge-wasm"; // todo: should be able to import from @automerge/automerge
+import { Hash, Heads } from "@automerge/automerge-wasm"; // todo: should be able to import from @automerge/automerge
 import {
   MarkdownDocChangeGroup,
   showChangeGroupInLog,

--- a/src/patchwork/groupChanges.ts
+++ b/src/patchwork/groupChanges.ts
@@ -323,7 +323,7 @@ export const getGroupedChanges = (
           decodedChangesForDoc: changes,
           branchHeads: branch.mergeMetadata.mergeHeads,
           mainHeads: getHeads(doc),
-          baseHeads: branch.branchHeads,
+          baseHeads: branch.branchHeads ?? [],
         }),
         mergeMetadata: branch.mergeMetadata,
       };

--- a/src/patchwork/groupChanges.ts
+++ b/src/patchwork/groupChanges.ts
@@ -1,3 +1,16 @@
+// This file puts changes from a doc into groups for display in the UI.
+// There are various algorithms that can govern what makes a group.
+// It can accept manual markers to split groups.
+
+// It also calculates some stats for each group, both generic to all docs
+// as well as calling out to some datatype-specific summarization.
+// (For now, the datatype is fixed to MarkdownDoc, but there is a clear boundary;
+// the TEE code defines MarkdownDoc-specific stats.)
+
+// Known issues:
+// - getAllChanges returns different orders on different devices;
+//   we should define a total order for changes across all devices.
+
 import { MarkdownDoc } from "@/tee/schema";
 import {
   Branch,
@@ -14,16 +27,20 @@ import {
   decodeChange,
   ActorId,
   DecodedChange,
-  Patch,
   getAllChanges,
   view,
 } from "@automerge/automerge/next";
-import { TextPatch, diffWithProvenance } from "./utils";
+import { diffWithProvenance } from "./utils";
 import {
   ChangeMetadata,
   DocHandle,
 } from "@automerge/automerge-repo/dist/DocHandle";
-import { Heads, PatchWithAttr } from "@automerge/automerge-wasm"; // todo: should be able to import from @automerge/automerge
+import { Hash, Heads } from "@automerge/automerge-wasm"; // todo: should be able to import from @automerge/automerge
+import {
+  MarkdownDocChangeGroup,
+  showChangeGroupInLog,
+  statsForChangeGroup,
+} from "@/tee/statsForChangeGroup";
 
 interface DecodedChangeWithMetadata extends DecodedChange {
   metadata: ChangeMetadata;
@@ -43,32 +60,21 @@ export type HeadsMarker = { heads: Heads; hideHistoryBeforeThis?: boolean } & (
 );
 
 /** Change group attributes that could work for any document */
-type GenericChangeGroup = {
+export type GenericChangeGroup = {
   id: string;
   changes: DecodedChangeWithMetadata[];
   actorIds: ActorId[];
   authorUrls: AutomergeUrl[];
-  // TODO make this a generic type
+  // TODO make this a generic type --
+  // making it Doc<unknown> highlights the places where we currently expect
+  // this to be a MarkdownDoc that need to be generalized more.
   docAtEndOfChangeGroup: Doc<MarkdownDoc>;
   diff: DiffWithProvenance;
   markers: HeadsMarker[];
   time?: number;
 };
 
-/** These attributes are specific to TEE.
- *  Eventually they should somehow be specified by the Essay datatype.
- */
-type TEEChangeGroup = {
-  /* number of distinct edit ranges */
-  editCount: number;
-
-  charsAdded: number;
-  charsDeleted: number;
-  headings: Heading[];
-  commentsAdded: number;
-};
-
-export type ChangeGroup = GenericChangeGroup & TEEChangeGroup;
+export type ChangeGroup = GenericChangeGroup & MarkdownDocChangeGroup;
 
 type GroupingAlgorithm = (
   currentGroup: ChangeGroup,
@@ -77,6 +83,7 @@ type GroupingAlgorithm = (
 ) => boolean;
 
 // A grouping algorithm returns a boolean denoting whether the new change should be added to the current group.
+// Some of these algorithms rely on MarkdownDoc-specific stats; need to generalize that further.
 export const GROUPINGS: { [key in string]: GroupingAlgorithm } = {
   ByActorAndNumChanges: (currentGroup, newChange, batchSize) => {
     return (
@@ -212,9 +219,23 @@ export const getMarkersForDoc = <
     }
   }
 
-  console.log({ markers });
-
   return markers;
+};
+
+// NOTE: this should be pushed down the stack as we formalize
+// support for structured metadata on changes.
+const getAllChangesWithMetadata = (doc: Doc<unknown>) => {
+  return getAllChanges(doc).map((change) => {
+    let decodedChange = decodeChange(change) as DecodedChangeWithMetadata;
+    decodedChange.metadata = {};
+    try {
+      const metadata = JSON.parse(decodedChange.message);
+      decodedChange = { ...decodedChange, metadata };
+    } catch (e) {
+      // do nothing for now...
+    }
+    return decodedChange;
+  });
 };
 
 /* returns all the changes from this doc, grouped in a simple way for now. */
@@ -242,92 +263,30 @@ export const getGroupedChanges = (
     markers: [],
   }
 ) => {
-  const changes = getAllChanges(doc);
+  // TODO: we should sort this list in a stable way across devices.
+  const changes = getAllChangesWithMetadata(doc);
   const changeGroups: ChangeGroup[] = [];
 
   let currentGroup: ChangeGroup | null = null;
 
+  // define a helper for pushing a new group onto the list
   const pushCurrentGroup = () => {
     const diffHeads =
       changeGroups.length > 0 ? [changeGroups[changeGroups.length - 1].id] : [];
     currentGroup.diff = diffWithProvenance(doc, diffHeads, [currentGroup.id]);
+    currentGroup.docAtEndOfChangeGroup = view(doc, [currentGroup.id]);
 
-    // Finalize the stats on the group based on the diff
+    const TEEChangeGroup = statsForChangeGroup(currentGroup);
+    currentGroup = { ...currentGroup, ...TEEChangeGroup };
 
-    currentGroup.charsAdded = currentGroup.diff.patches.reduce(
-      (total, patch) => {
-        if (patch.path[0] !== "content") {
-          return total;
-        }
-        if (patch.action === "splice") {
-          return total + patch.value.length;
-        } else {
-          return total;
-        }
-      },
-      0
-    );
-
-    currentGroup.charsDeleted = currentGroup.diff.patches.reduce(
-      (total, patch) => {
-        if (patch.path[0] !== "content") {
-          return total;
-        }
-        if (patch.action === "del") {
-          return total + patch.length;
-        } else {
-          return total;
-        }
-      },
-      0
-    );
-
-    currentGroup.commentsAdded = currentGroup.diff.patches.reduce(
-      (total, patch) => {
-        const isNewComment =
-          patch.path[0] === "commentThreads" &&
-          patch.path.length === 4 &&
-          patch.action === "insert";
-
-        if (!isNewComment) {
-          return total;
-        } else {
-          return total + 1;
-        }
-      },
-      0
-    );
-
-    // GL 1/19: For now, only show a group if it edited the text or added a comment.
-    // THIS IS A HACK, revisit this logic and think about it more carefully!
-    if (
-      currentGroup.charsAdded === 0 &&
-      currentGroup.charsDeleted === 0 &&
-      currentGroup.commentsAdded === 0
-    ) {
+    if (!showChangeGroupInLog(currentGroup)) {
       return;
     }
-
-    currentGroup.docAtEndOfChangeGroup = view(doc, [currentGroup.id]);
-    currentGroup.headings = extractHeadings(
-      currentGroup.docAtEndOfChangeGroup,
-      currentGroup.diff.patches
-    );
-    currentGroup.editCount = currentGroup.diff.patches.filter(
-      (p) => p.path[0] === "content"
-    ).length;
     changeGroups.push(currentGroup);
   };
 
   for (let i = 0; i < changes.length; i++) {
-    const change = changes[i];
-    let decodedChange = decodeChange(change) as DecodedChangeWithMetadata;
-    decodedChange.metadata = {};
-
-    try {
-      const metadata = JSON.parse(decodedChange.message);
-      decodedChange = { ...decodedChange, metadata };
-    } catch (e) {}
+    const decodedChange = changes[i];
 
     // Choose whether to add this change to the existing group or start a new group depending on the algorithm.
     if (
@@ -377,13 +336,8 @@ export const getGroupedChanges = (
         id: decodedChange.hash,
         changes: [decodedChange],
         actorIds: [decodedChange.actor],
-        charsAdded: decodedChange.ops.reduce((total, op) => {
-          // @ts-ignore
-          return op.action === "set" && op.insert === true ? total + 1 : total;
-        }, 0),
-        charsDeleted: decodedChange.ops.reduce((total, op) => {
-          return op.action === "del" ? total + 1 : total;
-        }, 0),
+        charsAdded: 0,
+        charsDeleted: 0,
         commentsAdded: 0,
         diff: { patches: [], fromHeads: [], toHeads: [] },
         markers: [],
@@ -407,167 +361,3 @@ export const getGroupedChanges = (
 
   return { changeGroups, changeCount: changes.length };
 };
-
-export type Heading = {
-  index: number;
-  text: string;
-  patches: Patch[];
-};
-
-// todo: doesn't handle replace
-export const extractHeadings = (
-  doc: MarkdownDoc,
-  patches: (Patch | TextPatch)[]
-): Heading[] => {
-  const headingData: Heading[] = [];
-  const regex = /^##\s(.*)/gm;
-  let match;
-
-  while ((match = regex.exec(doc.content)) != null) {
-    headingData.push({ index: match.index, text: match[1], patches: [] });
-  }
-
-  for (const patch of patches) {
-    if (
-      patch.path[0] !== "content" ||
-      !["splice", "del"].includes(patch.action)
-    ) {
-      continue;
-    }
-    let patchStart: number, patchEnd: number;
-    switch (patch.action) {
-      case "del": {
-        patchStart = patch.path[1] as number;
-        patchEnd = patchStart + patch.length;
-        break;
-      }
-      case "splice": {
-        patchStart = patch.path[1] as number;
-        patchEnd = patchStart + patch.value.length;
-        break;
-      }
-      default: {
-        continue;
-      }
-    }
-
-    // The heading was edited if it overlaps with the patch.
-    for (let i = 0; i < headingData.length; i++) {
-      const heading = headingData[i];
-      if (heading.index >= patchStart && heading.index <= patchEnd) {
-        heading.patches.push(patch);
-      }
-      if (
-        heading.index < patchStart &&
-        headingData[i + 1]?.index > patchStart
-      ) {
-        heading.patches.push(patch);
-      }
-    }
-  }
-
-  return headingData;
-};
-
-export const charsAddedAndDeletedByPatches = (
-  patches: Patch[]
-): { charsAdded: number; charsDeleted: number } => {
-  return patches.reduce(
-    (acc, patch) => {
-      if (patch.action === "splice") {
-        acc.charsAdded += patch.value.length;
-      } else if (patch.action === "del") {
-        acc.charsDeleted += patch.length;
-      }
-      return acc;
-    },
-    { charsAdded: 0, charsDeleted: 0 }
-  );
-};
-
-type PatchGroup = {
-  groupStartIndex: number;
-  groupEndIndex: number;
-  patches: (Patch | TextPatch)[];
-};
-
-// This is a quick hacky grouping
-// Probably better to iterate over patches rather than groups..?
-const groupPatchesByDelimiter =
-  (delimiter: string) =>
-  (doc: MarkdownDoc, patches: (Patch | TextPatch)[]): PatchGroup[] => {
-    if (!doc?.content) return [];
-    const patchGroups: PatchGroup[] = [];
-
-    let currentGroup: PatchGroup | null = null;
-
-    const createNewGroupFromPatch = (patch: Patch | TextPatch) => {
-      const patchStart = patch.path[1] as number;
-      const patchEnd = patchStart + getSizeOfPatch(patch);
-      const groupStartIndex =
-        doc.content.lastIndexOf(delimiter, patchStart) + 1;
-      const groupEndIndex = doc.content.indexOf(delimiter, patchEnd);
-      return {
-        groupStartIndex: groupStartIndex >= 0 ? groupStartIndex : patchStart,
-        groupEndIndex: groupEndIndex >= 0 ? groupEndIndex : patchEnd,
-        patches: [patch],
-      };
-    };
-
-    for (let i = 0; i < patches.length; i++) {
-      const patch = patches[i];
-      if (
-        patch.path[0] !== "content" ||
-        !["splice", "del"].includes(patch.action)
-      ) {
-        continue;
-      }
-
-      const patchStart = patch.path[1] as number;
-      const patchEnd = patchStart + getSizeOfPatch(patch);
-
-      if (currentGroup) {
-        if (patchStart <= currentGroup.groupEndIndex) {
-          currentGroup.patches.push(patch);
-          if (patchEnd > currentGroup.groupEndIndex) {
-            currentGroup.groupEndIndex = patchEnd;
-          }
-        } else {
-          patchGroups.push(currentGroup);
-          currentGroup = createNewGroupFromPatch(patch);
-        }
-      } else {
-        currentGroup = createNewGroupFromPatch(patch);
-      }
-    }
-
-    if (currentGroup) {
-      patchGroups.push(currentGroup);
-    }
-
-    return patchGroups;
-  };
-
-const getSizeOfPatch = (patch: Patch | TextPatch): number => {
-  switch (patch.action) {
-    case "del":
-      return patch.length;
-    case "splice":
-      return patch.value.length;
-    default:
-      throw new Error("unsupported patch type");
-  }
-};
-
-export const getAttrOfPatch = <T>(
-  patch: Patch | PatchWithAttr<T> | TextPatch
-): T | undefined => {
-  if (patch.action === "replace") {
-    return getAttrOfPatch(patch.raw.splice); // todo: this is not correct delete and insert could be from different authors
-  }
-
-  return "attr" in patch ? patch.attr : undefined;
-};
-
-export const groupPatchesByLine = groupPatchesByDelimiter("\n");
-export const groupPatchesByParagraph = groupPatchesByDelimiter("\n\n");

--- a/src/patchwork/groupChanges.ts
+++ b/src/patchwork/groupChanges.ts
@@ -274,7 +274,6 @@ export const getGroupedChanges = (
 
   // define a helper for pushing a new group onto the list
   const pushGroup = (group: ChangeGroup) => {
-    console.log("push group", structuredClone(group));
     const diffHeads =
       changeGroups.length > 0 ? [changeGroups[changeGroups.length - 1].id] : [];
     group.diff = diffWithProvenance(doc, diffHeads, [group.id]);
@@ -330,8 +329,6 @@ export const getGroupedChanges = (
     }
   }
 
-  console.log("branch change groups", branchChangeGroups);
-
   // Now we loop over the changes and make our groups.
   for (let i = 0; i < changes.length; i++) {
     const decodedChange = changes[i];
@@ -341,8 +338,6 @@ export const getGroupedChanges = (
     let changeCameFromMergedBranch = false;
     for (const branchChangeGroup of Object.values(branchChangeGroups)) {
       if (branchChangeGroup.changeHashes.has(decodedChange.hash)) {
-        console.log("CHANGE: from merged branch!");
-
         // Now that we've hit changes from a branch, cut off the current group that was formed on main.
         // (TODO: maybe we should be looking out for "branch started" markers on the primary loop instead?)
         if (currentGroup) {
@@ -382,12 +377,6 @@ export const getGroupedChanges = (
             decodedChange.hash
           )
         ) {
-          console.log("time to push branch change group", decodedChange.hash);
-          console.log("markers", markers);
-          console.log(
-            "Merge heads",
-            branchChangeGroup.mergeMetadata.mergeHeads
-          );
           const mergeMarker = markers.find(
             (marker) =>
               isEqual(
@@ -396,9 +385,7 @@ export const getGroupedChanges = (
               ) && marker.type === "otherBranchMergedIntoThisDoc"
           );
           if (mergeMarker) {
-            console.log("found merge marker");
             branchChangeGroup.changeGroup.markers.push(mergeMarker);
-            console.log("bcg", structuredClone(branchChangeGroup));
           }
 
           // todo: what other finalizing do we need to do here..? any?
@@ -411,8 +398,6 @@ export const getGroupedChanges = (
 
     if (changeCameFromMergedBranch) {
       continue;
-    } else {
-      console.log("CHANGE: not from merged branch");
     }
 
     // Choose whether to add this change to the existing group or start a new group depending on the algorithm.

--- a/src/patchwork/groupPatches.ts
+++ b/src/patchwork/groupPatches.ts
@@ -1,0 +1,89 @@
+import { MarkdownDoc } from "@/tee/schema";
+import { Patch } from "@automerge/automerge/next";
+import { TextPatch } from "./utils";
+import { PatchWithAttr } from "@automerge/automerge-wasm";
+
+type PatchGroup = {
+  groupStartIndex: number;
+  groupEndIndex: number;
+  patches: (Patch | TextPatch)[];
+};
+// This is a quick hacky grouping
+// Probably better to iterate over patches rather than groups..?
+const groupPatchesByDelimiter =
+  (delimiter: string) =>
+  (doc: MarkdownDoc, patches: (Patch | TextPatch)[]): PatchGroup[] => {
+    if (!doc?.content) return [];
+    const patchGroups: PatchGroup[] = [];
+
+    let currentGroup: PatchGroup | null = null;
+
+    const createNewGroupFromPatch = (patch: Patch | TextPatch) => {
+      const patchStart = patch.path[1] as number;
+      const patchEnd = patchStart + getSizeOfPatch(patch);
+      const groupStartIndex =
+        doc.content.lastIndexOf(delimiter, patchStart) + 1;
+      const groupEndIndex = doc.content.indexOf(delimiter, patchEnd);
+      return {
+        groupStartIndex: groupStartIndex >= 0 ? groupStartIndex : patchStart,
+        groupEndIndex: groupEndIndex >= 0 ? groupEndIndex : patchEnd,
+        patches: [patch],
+      };
+    };
+
+    for (let i = 0; i < patches.length; i++) {
+      const patch = patches[i];
+      if (
+        patch.path[0] !== "content" ||
+        !["splice", "del"].includes(patch.action)
+      ) {
+        continue;
+      }
+
+      const patchStart = patch.path[1] as number;
+      const patchEnd = patchStart + getSizeOfPatch(patch);
+
+      if (currentGroup) {
+        if (patchStart <= currentGroup.groupEndIndex) {
+          currentGroup.patches.push(patch);
+          if (patchEnd > currentGroup.groupEndIndex) {
+            currentGroup.groupEndIndex = patchEnd;
+          }
+        } else {
+          patchGroups.push(currentGroup);
+          currentGroup = createNewGroupFromPatch(patch);
+        }
+      } else {
+        currentGroup = createNewGroupFromPatch(patch);
+      }
+    }
+
+    if (currentGroup) {
+      patchGroups.push(currentGroup);
+    }
+
+    return patchGroups;
+  };
+const getSizeOfPatch = (patch: Patch | TextPatch): number => {
+  switch (patch.action) {
+    case "del":
+      return patch.length;
+    case "splice":
+      return patch.value.length;
+    default:
+      throw new Error("unsupported patch type");
+  }
+};
+
+export const getAttrOfPatch = <T>(
+  patch: Patch | PatchWithAttr<T> | TextPatch
+): T | undefined => {
+  if (patch.action === "replace") {
+    return getAttrOfPatch(patch.raw.splice); // todo: this is not correct delete and insert could be from different authors
+  }
+
+  return "attr" in patch ? patch.attr : undefined;
+};
+
+export const groupPatchesByLine = groupPatchesByDelimiter("\n");
+export const groupPatchesByParagraph = groupPatchesByDelimiter("\n\n");

--- a/src/tee/components/CommentsSidebar.tsx
+++ b/src/tee/components/CommentsSidebar.tsx
@@ -52,7 +52,7 @@ import { truncate } from "lodash";
 import { useDocument } from "@/useDocumentVendored";
 import { AutomergeUrl } from "@automerge/automerge-repo";
 import { ReadonlySnippetView } from "./ReadonlySnippetView";
-import { getAttrOfPatch } from "@/patchwork/groupChanges";
+import { getAttrOfPatch } from "@/patchwork/groupPatches";
 import { HistoryFilter } from "./HistoryFilter";
 import { TextPatch, getCursorPositionSafely } from "@/patchwork/utils";
 import { useHandle } from "@automerge/automerge-repo-react-hooks";

--- a/src/tee/statsForChangeGroup.ts
+++ b/src/tee/statsForChangeGroup.ts
@@ -1,0 +1,164 @@
+import { GenericChangeGroup } from "@/patchwork/groupChanges";
+
+import { TextPatch } from "@/patchwork/utils";
+import { Patch } from "@automerge/automerge-wasm";
+import { MarkdownDoc } from "./schema";
+
+export type MarkdownDocChangeGroup = {
+  /* number of distinct edit ranges */
+  editCount: number;
+
+  charsAdded: number;
+  charsDeleted: number;
+  headings: Heading[];
+  commentsAdded: number;
+};
+
+export type Heading = {
+  index: number;
+  text: string;
+  patches: Patch[];
+};
+
+// Compute stats for a change group on a MarkdownDoc
+
+export const statsForChangeGroup = (
+  changeGroup: GenericChangeGroup
+): MarkdownDocChangeGroup => {
+  const charsAdded = changeGroup.diff.patches.reduce((total, patch) => {
+    if (patch.path[0] !== "content") {
+      return total;
+    }
+    if (patch.action === "splice") {
+      return total + patch.value.length;
+    } else {
+      return total;
+    }
+  }, 0);
+
+  const charsDeleted = changeGroup.diff.patches.reduce((total, patch) => {
+    if (patch.path[0] !== "content") {
+      return total;
+    }
+    if (patch.action === "del") {
+      return total + patch.length;
+    } else {
+      return total;
+    }
+  }, 0);
+
+  const commentsAdded = changeGroup.diff.patches.reduce((total, patch) => {
+    const isNewComment =
+      patch.path[0] === "commentThreads" &&
+      patch.path.length === 4 &&
+      patch.action === "insert";
+
+    if (!isNewComment) {
+      return total;
+    } else {
+      return total + 1;
+    }
+  }, 0);
+
+  const headings = extractHeadings(
+    changeGroup.docAtEndOfChangeGroup as MarkdownDoc,
+    changeGroup.diff.patches
+  );
+  const editCount = changeGroup.diff.patches.filter(
+    (p) => p.path[0] === "content"
+  ).length;
+
+  return {
+    editCount,
+    charsAdded,
+    charsDeleted,
+    headings,
+    commentsAdded,
+  };
+};
+
+// This is a MarkdownDoc-specific function that determines whether a change group
+// should be shown in the log.
+export const showChangeGroupInLog = (
+  changeGroup: MarkdownDocChangeGroup & GenericChangeGroup
+) => {
+  if (
+    changeGroup.charsAdded === 0 &&
+    changeGroup.charsDeleted === 0 &&
+    changeGroup.commentsAdded === 0
+  ) {
+    return false;
+  } else {
+    return true;
+  }
+};
+
+// todo: doesn't handle replace
+export const extractHeadings = (
+  doc: MarkdownDoc,
+  patches: (Patch | TextPatch)[]
+): Heading[] => {
+  const headingData: Heading[] = [];
+  const regex = /^##\s(.*)/gm;
+  let match;
+
+  while ((match = regex.exec(doc.content)) != null) {
+    headingData.push({ index: match.index, text: match[1], patches: [] });
+  }
+
+  for (const patch of patches) {
+    if (
+      patch.path[0] !== "content" ||
+      !["splice", "del"].includes(patch.action)
+    ) {
+      continue;
+    }
+    let patchStart: number, patchEnd: number;
+    switch (patch.action) {
+      case "del": {
+        patchStart = patch.path[1] as number;
+        patchEnd = patchStart + patch.length;
+        break;
+      }
+      case "splice": {
+        patchStart = patch.path[1] as number;
+        patchEnd = patchStart + patch.value.length;
+        break;
+      }
+      default: {
+        continue;
+      }
+    }
+
+    // The heading was edited if it overlaps with the patch.
+    for (let i = 0; i < headingData.length; i++) {
+      const heading = headingData[i];
+      if (heading.index >= patchStart && heading.index <= patchEnd) {
+        heading.patches.push(patch);
+      }
+      if (
+        heading.index < patchStart &&
+        headingData[i + 1]?.index > patchStart
+      ) {
+        heading.patches.push(patch);
+      }
+    }
+  }
+
+  return headingData;
+};
+export const charsAddedAndDeletedByPatches = (
+  patches: Patch[]
+): { charsAdded: number; charsDeleted: number } => {
+  return patches.reduce(
+    (acc, patch) => {
+      if (patch.action === "splice") {
+        acc.charsAdded += patch.value.length;
+      } else if (patch.action === "del") {
+        acc.charsDeleted += patch.length;
+      }
+      return acc;
+    },
+    { charsAdded: 0, charsDeleted: 0 }
+  );
+};

--- a/test/compareBranches.test.ts
+++ b/test/compareBranches.test.ts
@@ -1,0 +1,209 @@
+import assert from "assert";
+import { describe, it } from "vitest";
+import { compareBranchToMain } from "../src/patchwork/branches";
+import * as A from "@automerge/automerge/next";
+
+describe("compareBranches", () => {
+  it("returns a single change on a branch, with nothing else concurrent on main", () => {
+    //  x main
+    //   \
+    //    \
+    //     x branch
+
+    const emptyDoc = A.init<any>();
+    const mainDoc = A.change(emptyDoc, (d) => {
+      d.content = "hello";
+    });
+    const baseHeads = A.getHeads(mainDoc);
+    const branchDoc = A.change(mainDoc, (d) => {
+      d.content = "world";
+    });
+    const branchHeads = A.getHeads(branchDoc);
+
+    // merge!
+    const finalDoc = A.merge(A.clone(branchDoc), A.clone(mainDoc));
+    const decodedChanges = A.getAllChanges(finalDoc).map((change) =>
+      A.decodeChange(change)
+    );
+
+    const result = compareBranchToMain({
+      decodedChangesForDoc: decodedChanges,
+      branchHeads,
+      // main hasn't moved past the base in this case
+      mainHeads: baseHeads,
+      baseHeads,
+    });
+
+    assert.deepEqual(result, {
+      onlyInMain: new Set([]),
+      onlyInBranch: new Set([branchHeads[0]]),
+    });
+  });
+
+  it("returns 2 changes on a branch, with nothing else concurrent on main", () => {
+    //  x main
+    //   \
+    //    \
+    //     x
+    //     |
+    //     x branch
+
+    const emptyDoc = A.init<any>();
+    const baseDoc = A.change(emptyDoc, (d) => {
+      d.content = "hello";
+    });
+    const baseHeads = A.getHeads(baseDoc);
+
+    // make 2 changes on the branch
+    const branchChangeHashes = [];
+    let branchDoc = A.change(baseDoc, (d) => {
+      d.content = "world";
+    });
+    branchChangeHashes.push(A.getHeads(branchDoc)[0]);
+    branchDoc = A.change(branchDoc, (d) => {
+      d.content = "yo";
+    });
+    branchChangeHashes.push(A.getHeads(branchDoc)[0]);
+    const branchHeads = A.getHeads(branchDoc);
+
+    // merge!
+    const finalDoc = A.merge(A.clone(branchDoc), A.clone(baseDoc));
+    const decodedChanges = A.getAllChanges(finalDoc).map((change) =>
+      A.decodeChange(change)
+    );
+
+    const result = compareBranchToMain({
+      decodedChangesForDoc: decodedChanges,
+      branchHeads,
+      // main hasn't moved past the base in this case
+      mainHeads: baseHeads,
+      baseHeads,
+    });
+
+    assert.deepEqual(result, {
+      onlyInMain: new Set([]),
+      onlyInBranch: new Set(branchChangeHashes),
+    });
+  });
+
+  it("returns 2 changes on a branch, with 1 change concurrent on main", () => {
+    //     x
+    //     |\
+    //     | \
+    //main x  x
+    //        |
+    //        x branch
+
+    const emptyDoc = A.init<any>();
+    const baseDoc = A.change(emptyDoc, (d) => {
+      d.content = "hello";
+    });
+    const baseHeads = A.getHeads(baseDoc);
+
+    // make 2 changes on the branch
+    const branchChangeHashes = [];
+    let branchDoc = A.change(A.clone(baseDoc), (d) => {
+      d.content = "world";
+    });
+    branchChangeHashes.push(A.getHeads(branchDoc)[0]);
+    branchDoc = A.change(branchDoc, (d) => {
+      d.content = "yo";
+    });
+    branchChangeHashes.push(A.getHeads(branchDoc)[0]);
+    const branchHeads = A.getHeads(branchDoc);
+
+    const mainDoc = A.change(A.clone(baseDoc), (d) => {
+      d.content = "bar";
+    });
+    const mainHeads = A.getHeads(mainDoc);
+
+    const finalDoc = A.merge(A.clone(branchDoc), A.clone(mainDoc));
+    const decodedChanges = A.getAllChanges(finalDoc).map((change) =>
+      A.decodeChange(change)
+    );
+
+    const result = compareBranchToMain({
+      decodedChangesForDoc: decodedChanges,
+      branchHeads,
+      mainHeads,
+      baseHeads,
+    });
+
+    assert.deepEqual(result, {
+      onlyInMain: new Set(mainHeads),
+      onlyInBranch: new Set(branchChangeHashes),
+    });
+  });
+
+  it("returns 3 changes on a branch, with 1 change concurrent on main, and main merged into branch", () => {
+    // this case is a bit trickier than the ones above.
+    // we need to make sure we differentiate between the change that happened on main
+    // vs the ones that happened only on the branch
+
+    //     x
+    //     |\
+    //     | \
+    //main x  x
+    //      \ |
+    //        x
+    //        |
+    //        x branch
+
+    const emptyDoc = A.init<any>();
+    const baseDoc = A.change(emptyDoc, (d) => {
+      d.content = "hello";
+    });
+    const baseHeads = A.getHeads(baseDoc);
+
+    // make 1 changes on the branch
+    const branchChangeHashes = [];
+    let branchDoc = A.change(A.clone(baseDoc), (d) => {
+      d.content = "world";
+    });
+    branchChangeHashes.push(A.getHeads(branchDoc)[0]);
+
+    // 1 change on main
+    const mainDoc = A.change(A.clone(baseDoc), (d) => {
+      d.content = "bar";
+    });
+    const mainHeads = A.getHeads(mainDoc);
+
+    // merge main into branch
+    branchDoc = A.merge(A.clone(mainDoc), A.clone(branchDoc));
+
+    // make 2 more changes on the branch
+    branchDoc = A.change(A.clone(branchDoc), (d) => {
+      d.content = "yo";
+    });
+    branchChangeHashes.push(A.getHeads(branchDoc)[0]);
+
+    branchDoc = A.change(A.clone(branchDoc), (d) => {
+      d.content = "whee";
+    });
+    branchChangeHashes.push(A.getHeads(branchDoc)[0]);
+
+    const branchHeads = A.getHeads(branchDoc);
+
+    const finalDoc = A.merge(A.clone(branchDoc), A.clone(mainDoc));
+    const decodedChanges = A.getAllChanges(finalDoc).map((change) =>
+      A.decodeChange(change)
+    );
+
+    const result = compareBranchToMain({
+      decodedChangesForDoc: decodedChanges,
+      branchHeads,
+      mainHeads,
+      baseHeads,
+    });
+
+    assert.equal(branchChangeHashes.length, 3);
+
+    assert.deepEqual(result, {
+      // the branch has everything in main
+      onlyInMain: new Set([]),
+
+      // the branch also has 3 changes not in main
+      onlyInBranch: new Set(branchChangeHashes),
+    });
+  });
+});


### PR DESCRIPTION
This PR shows changes from a merged branch on a doc inside the "merge commit" on the sidebar.

## UI

Here's what it looks like

<img width="389" alt="CleanShot 2024-02-22 at 18 37 10@2x" src="https://github.com/inkandswitch/tiny-essay-editor/assets/934016/5a7a836b-6270-45a9-998f-b1e0ed7ba52a">

https://github.com/inkandswitch/tiny-essay-editor/assets/934016/e11c3d94-bfd6-4cde-8e39-f7a2c8546cc5

## Algorithm

Thanks to @pvh for contributing the idea for the algorithm for ID'ing changes from the merged branch.

For each merged branch on the doc, we remember the heads where it started, and the heads right before it merged. We can look thru the change DAG and figure out which changes were the ones that came from the branch and not directly from main. See the code in `branches.ts` for more details.

I have a few unit tests passing for various cases, and it works in some simple cases for real docs. Still more testing needed to fully see if it's working right.

The tests have ASCII art :)
<img width="755" alt="CleanShot 2024-02-22 at 18 47 41@2x" src="https://github.com/inkandswitch/tiny-essay-editor/assets/934016/6acd4864-1169-4989-a1c0-5f8c28b60faf">


## Integration w/ change grouper

The basic idea is to create one special change group for each merged branch.

Before we start grouping, we write enumerate sets of change hashes claimed by each merged branch. Anytime the grouper hits a change that's claimed by a merged branch, it routes that change into the branch's change group instead of the regular group it would have gone into otherwise.

A branch's change group gets added to the list of change groups once we hit the last change on the branch pre-merge.

(This all seems sensible as a first iteration over our previous grouping strategy to me... We still need to think about what to do re: ordering changes the same on all devices which might affect this stuff.)

## Grouper refactoring

I also started extracting out some of the markdown doc specific logic from the change grouper into the TEE data type. I'd say it's ~80% extracted, but still some stragglers to handle.

## I'm merging it

This isn't that heavily QA'd yet but it seems stable enough to merge into `patchwork` which has lots of sketchy code in it already. I'd rather merge than have diverging branches and rebasing issues since this branch does a lot.