### PR TITLE
allow pasting in urls with embedded automerge urls

### DIFF
--- a/src/DocExplorer/components/Sidebar.tsx
+++ b/src/DocExplorer/components/Sidebar.tsx
@@ -67,7 +67,10 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const [openNewDocPopoverVisible, setOpenNewDocPopoverVisible] =
     useState(false);
   const [openUrlInput, setOpenUrlInput] = useState("");
-  const automergeUrlMatch = openUrlInput.match(/(automerge:[a-zA-Z0-9]*)/);
+  const automergeUrlMatch =
+    openUrlInput
+    .replace(/%3A/g, ':')
+    .match(/(automerge:[a-zA-Z0-9]*)/);
   const automergeUrlToOpen =
     automergeUrlMatch &&
     automergeUrlMatch[1] &&


### PR DESCRIPTION
Lots of tools (like TEE itself) put automerge urls in to app urls, so the `:` gets url-encoded into `%3A`. Let's unencode them for easier pasting.