### PR TITLE
suppress save shortcut

### DIFF
--- a/src/tee/codemirrorPlugins/suppressSaveShortcut.ts
+++ b/src/tee/codemirrorPlugins/suppressSaveShortcut.ts
@@ -1,0 +1,9 @@
+import { keymap } from '@codemirror/view';
+
+export const suppressSaveShortcut = keymap.of([{
+  key: "Mod-s",
+  run() {
+    // TODO: give a nice toast
+    return true;
+  },
+}]);

--- a/src/tee/components/MarkdownEditor.tsx
+++ b/src/tee/components/MarkdownEditor.tsx
@@ -39,6 +39,7 @@ import {
   threadsField,
 } from "../codemirrorPlugins/commentThreads";
 import { lineWrappingPlugin } from "../codemirrorPlugins/lineWrapping";
+import { suppressSaveShortcut } from "../codemirrorPlugins/suppressSaveShortcut";
 
 export type TextSelection = {
   from: number;
@@ -125,6 +126,7 @@ export function MarkdownEditor({
         tableOfContentsPreviewPlugin,
         codeMonospacePlugin,
         lineWrappingPlugin,
+        suppressSaveShortcut,
       ],
       dispatch(transaction, view) {
         // TODO: can some of these dispatch handlers be factored out into plugins?


### PR DESCRIPTION
I'm always pressing Cmd-S reflexively, and the browser "save" window pops up, and it's annoying. This disables that.

Really, there should be a cute little "toast" that pops up inoffensively to say "no need to save!" or whatever. I'd be happy to add that – I'd probably use https://github.com/timolins/react-hot-toast cuz I just learned it, but I can follow alternative instructions.