### PR TITLE
Branch in URL for sharing

### DIFF
--- a/src/DocExplorer/components/DocExplorer.tsx
+++ b/src/DocExplorer/components/DocExplorer.tsx
@@ -108,17 +108,14 @@ export const DocExplorer: React.FC = () => {
 
   const {
     selectedDoc,
-    selectDoc,
     selectedDocUrl,
     selectedBranch,
+    selectDoc,
     selectBranch,
   } = useSelectedDoc({
     rootFolderDoc,
     changeRootFolderDoc,
   });
-
-  console.log("selected doc url", selectedDocUrl);
-  console.log("selected branch", selectedBranch);
 
   const selectedDocLink = rootFolderDoc?.docs.find(
     (doc) => doc.url === selectedDocUrl
@@ -380,6 +377,8 @@ const parseCurrentUrlHash = (): UrlHashParams => {
     return null;
   }
 
+  // NOTE: the URL may contain a branchUrl, which we need to turn into a SelectedBranch value
+  // If it's missing, the selected branch is main.
   const selectedBranch: SelectedBranch =
     branchUrl && typeof branchUrl === "string" && isValidAutomergeUrl(branchUrl)
       ? { type: "branch", url: branchUrl }
@@ -392,9 +391,15 @@ const parseCurrentUrlHash = (): UrlHashParams => {
   };
 };
 
-// Drive the currently selected doc using the URL hash
-// (We encapsulate the selection state in a hook so that the only
-// API for changing the selection is properly thru the URL)
+// Drive the currently selected doc using the URL hash.
+// The philosophy here is that any changes to the selected doc or branch
+// flow through the URL hash. This ensures that copying the current URL
+// will always correctly point to the right doc + branch.
+// To support this, we expose functions for selecting a doc or a branch,
+// which route through the URL hash, and then we expose the currently
+// selected doc + branch as data values as well.
+// The React state for the selection is privately encapsulated and
+// is not meant to be directly accessed.
 const useSelectedDoc = ({ rootFolderDoc, changeRootFolderDoc }) => {
   const [selectedDocUrl, setSelectedDocUrl] = useState<AutomergeUrl>(null);
   const selectedDocHandle = useHandle(selectedDocUrl);
@@ -439,7 +444,6 @@ const useSelectedDoc = ({ rootFolderDoc, changeRootFolderDoc }) => {
       docType: DocType;
       branch?: SelectedBranch;
     }) => {
-      console.log("openDocFromUrl", docUrl, docType, branch);
       if (!rootFolderDoc) {
         return;
       }
@@ -489,9 +493,9 @@ const useSelectedDoc = ({ rootFolderDoc, changeRootFolderDoc }) => {
   return {
     selectedDocUrl,
     selectedDoc,
+    selectedBranch,
     selectDoc,
     openDocFromUrl,
-    selectedBranch,
     selectBranch,
   };
 };

--- a/src/DocExplorer/components/DocExplorer.tsx
+++ b/src/DocExplorer/components/DocExplorer.tsx
@@ -106,10 +106,19 @@ export const DocExplorer: React.FC = () => {
   const [showSidebar, setShowSidebar] = useState(false);
   const [showToolPicker, setShowToolPicker] = useState(false);
 
-  const { selectedDoc, selectDoc, selectedDocUrl } = useSelectedDoc({
+  const {
+    selectedDoc,
+    selectDoc,
+    selectedDocUrl,
+    selectedBranch,
+    selectBranch,
+  } = useSelectedDoc({
     rootFolderDoc,
     changeRootFolderDoc,
   });
+
+  console.log("selected doc url", selectedDocUrl);
+  console.log("selected branch", selectedBranch);
 
   const selectedDocLink = rootFolderDoc?.docs.find(
     (doc) => doc.url === selectedDocUrl
@@ -127,10 +136,6 @@ export const DocExplorer: React.FC = () => {
   }, [availableTools]);
 
   const ToolComponent = activeTool?.component;
-
-  const [selectedBranch, setSelectedBranch] = useState<SelectedBranch>({
-    type: "main",
-  });
 
   const addNewDocument = useCallback(
     ({ type }: { type: DocType }) => {
@@ -154,7 +159,11 @@ export const DocExplorer: React.FC = () => {
       );
 
       // By updating the URL to the new doc, we'll trigger a navigation
-      setUrlHashForDoc({ docUrl: newDocHandle.url, docType: type });
+      setUrlHashForDoc({
+        docUrl: newDocHandle.url,
+        docType: type,
+        branch: { type: "main" },
+      });
     },
     [changeRootFolderDoc, repo, rootFolderDoc]
   );
@@ -273,7 +282,7 @@ export const DocExplorer: React.FC = () => {
               selectedDocUrl={selectedDocUrl}
               selectDoc={selectDoc}
               deleteFromAccountDocList={deleteFromRootFolder}
-              setSelectedBranch={setSelectedBranch}
+              setSelectedBranch={selectBranch}
             />
             <div className="flex-grow overflow-hidden z-0">
               {!selectedDocUrl && (
@@ -301,7 +310,7 @@ export const DocExplorer: React.FC = () => {
                   key={selectedDocUrl}
                   // @ts-expect-error not all tools understand branching yet... but they probably will eventually..?
                   selectedBranch={selectedBranch}
-                  setSelectedBranch={setSelectedBranch}
+                  setSelectedBranch={selectBranch}
                 />
               )}
             </div>
@@ -332,6 +341,7 @@ export const DocExplorer: React.FC = () => {
 export type UrlHashParams = {
   docUrl: AutomergeUrl;
   docType: DocType;
+  branch?: SelectedBranch;
 } | null;
 
 const isDocType = (x: string): x is DocType =>
@@ -347,13 +357,14 @@ const parseCurrentUrlHash = (): UrlHashParams => {
   if (isValidAutomergeUrl(possibleAutomergeUrl)) {
     return {
       docUrl: possibleAutomergeUrl,
-      docType: "tldraw",
+      docType: "essay",
+      branch: { type: "main" },
     };
   }
 
   // Now on to the main logic where we look for a url and type both.
   const parsedHash = queryString.parse(hash);
-  const { docUrl, docType } = parsedHash;
+  const { docUrl, docType, branchUrl } = parsedHash;
 
   if (typeof docUrl !== "string" || typeof docType !== "string") {
     return null;
@@ -369,9 +380,15 @@ const parseCurrentUrlHash = (): UrlHashParams => {
     return null;
   }
 
+  const selectedBranch: SelectedBranch =
+    branchUrl && typeof branchUrl === "string" && isValidAutomergeUrl(branchUrl)
+      ? { type: "branch", url: branchUrl }
+      : { type: "main" };
+
   return {
     docUrl,
     docType,
+    branch: selectedBranch,
   };
 };
 
@@ -381,6 +398,9 @@ const parseCurrentUrlHash = (): UrlHashParams => {
 const useSelectedDoc = ({ rootFolderDoc, changeRootFolderDoc }) => {
   const [selectedDocUrl, setSelectedDocUrl] = useState<AutomergeUrl>(null);
   const selectedDocHandle = useHandle(selectedDocUrl);
+  const [selectedBranch, setSelectedBranch] = useState<SelectedBranch>({
+    type: "main",
+  });
 
   useEffect(() => {
     // @ts-expect-error window global for debugging
@@ -389,36 +409,62 @@ const useSelectedDoc = ({ rootFolderDoc, changeRootFolderDoc }) => {
 
   const [selectedDoc] = useDocument(selectedDocUrl);
 
-  const selectDoc = (docUrl: AutomergeUrl | null) => {
-    const doc = rootFolderDoc.docs.find((doc) => doc.url === docUrl);
-    if (!doc) {
-      alert(`Could not find document with URL: ${docUrl}`);
-      return;
-    }
-    setUrlHashForDoc({ docUrl, docType: doc.type });
-  };
+  const selectDoc = useCallback(
+    (docUrl: AutomergeUrl | null, branch?: SelectedBranch) => {
+      const doc = rootFolderDoc.docs.find((doc) => doc.url === docUrl);
+      if (!doc) {
+        alert(`Could not find document with URL: ${docUrl}`);
+        return;
+      }
+      setUrlHashForDoc({ docUrl, docType: doc.type, branch });
+    },
+    [rootFolderDoc]
+  );
 
-  // Add an existing doc to our collection
+  const selectBranch = useCallback(
+    (branch: SelectedBranch) => {
+      selectDoc(selectedDocUrl, branch);
+    },
+    [selectedDocUrl, selectDoc]
+  );
+
+  // open a doc given a URL
   const openDocFromUrl = useCallback(
-    ({ docUrl, docType }: { docUrl: AutomergeUrl; docType: DocType }) => {
+    ({
+      docUrl,
+      docType,
+      branch,
+    }: {
+      docUrl: AutomergeUrl;
+      docType: DocType;
+      branch?: SelectedBranch;
+    }) => {
+      console.log("openDocFromUrl", docUrl, docType, branch);
       if (!rootFolderDoc) {
         return;
       }
 
+      // First add it to our root folder if it's not there yet
       // TODO: validate the doc's data schema here before adding to our collection
       if (!rootFolderDoc?.docs.find((doc) => doc.url === docUrl)) {
         changeRootFolderDoc((doc) =>
           doc.docs.unshift({
             type: docType,
-            name: "Unknown document", // TODO: sync up the name once we load the data
+            name: "Unknown document", // The name will load once we load the doc
             url: docUrl,
           })
         );
       }
 
       setSelectedDocUrl(docUrl);
+      if (branch) {
+        setSelectedBranch(branch);
+      } else {
+        setSelectedBranch({ type: "main" });
+      }
     },
-    [rootFolderDoc, changeRootFolderDoc, selectDoc]
+    // [rootFolderDoc, changeRootFolderDoc, selectDoc, setSelectedBranch]
+    [rootFolderDoc]
   );
 
   // observe the URL hash to change the selected document
@@ -445,6 +491,8 @@ const useSelectedDoc = ({ rootFolderDoc, changeRootFolderDoc }) => {
     selectedDoc,
     selectDoc,
     openDocFromUrl,
+    selectedBranch,
+    selectBranch,
   };
 };
 export type SelectedBranch =

--- a/src/DocExplorer/utils.ts
+++ b/src/DocExplorer/utils.ts
@@ -16,11 +16,12 @@ export const setUrlHashForDoc = (params: UrlHashParams) => {
     return;
   }
 
-  const { docUrl, docType } = params;
+  const { docUrl, docType, branch } = params;
 
   const newHash = queryString.stringify({
     docUrl,
     docType,
+    branchUrl: branch?.type === "branch" ? branch.url : undefined,
   });
   window.location.hash = newHash;
 };

--- a/src/patchwork/components/Demo4/Demo4.tsx
+++ b/src/patchwork/components/Demo4/Demo4.tsx
@@ -24,6 +24,7 @@ import {
   GitBranchIcon,
   GitBranchPlusIcon,
   GitMergeIcon,
+  Link,
   MergeIcon,
   MessageSquareIcon,
   MilestoneIcon,
@@ -937,6 +938,21 @@ const BranchActions: React.FC<{
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent className="mr-4 w-72">
+        <DropdownMenuItem
+          onClick={() => {
+            navigator.clipboard.writeText(window.location.href).then(
+              () => {
+                toast("Link copied to clipboard");
+              },
+              () => {
+                toast.error("Failed to copy link to clipboard");
+              }
+            );
+          }}
+        >
+          <Link className="inline-block text-gray-500 mr-2" size={14} /> Copy
+          link to branch
+        </DropdownMenuItem>
         <DropdownMenuItem
           onClick={() => {
             const newName = prompt("Enter the new name for this branch:");

--- a/src/patchwork/components/Demo4/ReviewSidebar.tsx
+++ b/src/patchwork/components/Demo4/ReviewSidebar.tsx
@@ -339,7 +339,7 @@ export const ReviewSidebar: React.FC<{
                     <div className="ml-auto flex-shrink-0 flex items-center gap-2">
                       <div className="flex items-center space-x-[-4px]">
                         {item.users.map((contactUrl) => (
-                          <div className="rounded-full">
+                          <div className="rounded-full" key={contactUrl}>
                             <InlineContactAvatar
                               key={contactUrl}
                               url={contactUrl}
@@ -643,11 +643,11 @@ const BranchMergedItem: React.FC<{
             <div className="inline font-semibold">{branch.name}</div>{" "}
           </div>
           {changeGroups.map((group) => (
-            <div className="flex">
+            <div className="flex" key={group.id}>
               <ChangeGroupDescription changeGroup={group} doc={doc} />
               <div className="flex flex-shrink-0 items-start space-x-[-4px]">
                 {group.authorUrls.map((contactUrl) => (
-                  <div className="rounded-full">
+                  <div className="rounded-full" key={contactUrl}>
                     <InlineContactAvatar
                       key={contactUrl}
                       url={contactUrl}

--- a/src/patchwork/components/Demo4/ReviewSidebar.tsx
+++ b/src/patchwork/components/Demo4/ReviewSidebar.tsx
@@ -381,7 +381,7 @@ export const ReviewSidebar: React.FC<{
                                     "New summary:",
                                     doc.changeGroupSummaries[
                                       item.changeGroup.id
-                                    ].title ?? ""
+                                    ]?.title ?? ""
                                   );
                                   if (summary) {
                                     handle.change((doc) => {


### PR DESCRIPTION
This PR puts the branch in the URL so you can easily share a link to a branch.

As noted in `DocExplorer`, the general idea for routing in this app is that the doc and branch can only be changed through functions that update the URL hash; We then observe the hash to set the current selection. The result is that there is no way that the URL hash and selection can get out of sync.