### PR TITLE
improve performance of typing w/ timeline open

### DIFF
--- a/src/DocExplorer/doctypes.ts
+++ b/src/DocExplorer/doctypes.ts
@@ -34,11 +34,16 @@ export type PatchworkDataType<D, T, V> = {
   // TODO (GL 3/12/24): we'd like to unify these two filter methods
   // and possibly combine them with grouping logic soon.
 
-  // Mark whether a given change should be included in the history
+  // Mark whether a given change should be included in the history.
+  // Note: This function has a strange signature that takes in a doc and a change
+  // independently in a curried way. This is because we want to do doc-global
+  // stuff just once up front for performance, and then reuse when checking each change.
+  // (See the implementation for Markdown docs as one example.)
+  // If Automerge had more ergonomic APIs for observing what ops did, this wouldn't be needed.
   includeChangeInHistory?: (
-    doc: D,
-    change: DecodedChangeWithMetadata
-  ) => boolean;
+    doc: D
+  ) => (change: DecodedChangeWithMetadata) => boolean;
+
   // Mark whether a given patch should be included in the history
   includePatchInChangeGroup?: (patch: A.Patch | TextPatch) => boolean; // todo: can we get rid of TextPatch here?
 

--- a/src/datagrid/datatype.ts
+++ b/src/datagrid/datatype.ts
@@ -43,10 +43,7 @@ export const init = (doc: any) => {
   );
 };
 
-export const includeChangeInHistory = (
-  doc: DataGridDoc,
-  decodedChange: DecodedChangeWithMetadata
-) => {
+export const includeChangeInHistory = (doc: DataGridDoc) => {
   const dataObjId = A.getObjectId(doc, "data");
   // GL 3/11/24: this is miserable, we need to collect a whole bunch of object ids
   // for the rows inside the data object in order to filter changes.
@@ -54,12 +51,14 @@ export const includeChangeInHistory = (
   const rowObjIds = doc.data.map((_, index) => A.getObjectId(doc.data, index));
   const commentsObjID = A.getObjectId(doc, "commentThreads");
 
-  return decodedChange.ops.some(
-    (op) =>
-      op.obj === dataObjId ||
-      rowObjIds.includes(op.obj) ||
-      op.obj === commentsObjID
-  );
+  return (decodedChange: DecodedChangeWithMetadata) => {
+    return decodedChange.ops.some(
+      (op) =>
+        op.obj === dataObjId ||
+        rowObjIds.includes(op.obj) ||
+        op.obj === commentsObjID
+    );
+  };
 };
 
 export const includePatchInChangeGroup = (patch: A.Patch) =>

--- a/src/patchwork/ChangeGrouper.ts
+++ b/src/patchwork/ChangeGrouper.ts
@@ -1,0 +1,123 @@
+import { DocHandle, Repo } from "@automerge/automerge-repo";
+import { EventEmitter } from "eventemitter3";
+import {
+  ChangeGroup,
+  ChangeGroupingOptions,
+  ChangelogItem,
+  DecodedChangeWithMetadata,
+  getChangelogItems,
+  getMarkersForDoc,
+} from "./groupChanges";
+import { HasPatchworkMetadata } from "./schema";
+import { next as A } from "@automerge/automerge";
+import { debounce, isEqual } from "lodash";
+
+const GROUPER_DEBOUNCE_MS = 1000;
+
+/**This is a class that wraps a doc handle and emits events
+ * when the changelog items change.
+ * Most of the actual work gets delegated to getChangelogItems;
+ * the main purpose of this stateful class is to improve performance
+ * by maintaining a cache of decoded changes and by debouncing updates.
+ */
+export class ChangeGrouper<
+  D extends HasPatchworkMetadata<unknown, unknown>
+> extends EventEmitter {
+  private handle: DocHandle<D>;
+  private repo: Repo;
+  private groupingOptions: Omit<ChangeGroupingOptions<D>, "markers">;
+  // An array of decoded changes on the doc.
+  private decodedChanges: DecodedChangeWithMetadata[];
+  private debouncedListener;
+  items: ChangelogItem<D>[];
+
+  private memoizedGroups: {
+    changeGroups: ChangeGroup<D>[];
+    changeCount: number;
+    options: ChangeGroupingOptions<D>;
+  };
+
+  constructor(
+    handle: DocHandle<D>,
+    repo: Repo,
+    groupingOptions: Omit<ChangeGroupingOptions<D>, "markers">
+  ) {
+    super();
+    this.handle = handle;
+    this.repo = repo;
+    this.groupingOptions = groupingOptions;
+    this.debouncedListener = debounce(
+      () => this.populateItems(),
+      GROUPER_DEBOUNCE_MS
+    );
+    this.decodedChanges = [];
+
+    // Get change groups using initial state of the doc.
+    if (handle.docSync()) {
+      this.populateItems();
+    }
+
+    // Listen for changes to the doc and update the items array as needed.
+    let cachedMarkers;
+    handle.on("change", () => {
+      const markers = getMarkersForDoc(this.handle, this.repo);
+      if (!isEqual(markers, cachedMarkers)) {
+        // If the markers on the doc have changed, then we immediately recompute change groups
+        cachedMarkers = markers;
+        this.populateItems();
+      } else {
+        // If the markers haven't changed, then do a debounced recompute.
+        this.debouncedListener();
+      }
+    });
+  }
+
+  // Recompute changelog items for the current state of the doc
+  private populateItems() {
+    // This call to getAllChanges is still quite slow; it'd be a lot faster
+    // if Automerge simply had an API to get a subset of changes.
+    const rawChanges = A.getAllChanges(this.handle.docSync());
+
+    // Only decode new changes.
+    // Note, this only works because new changes are added to the end of the list;
+    // if that invariant changes we'll need a new way to keep track of which
+    // changes we've already decoded.
+
+    if (rawChanges.length > this.decodedChanges.length) {
+      const newDecodedChanges = rawChanges
+        .slice(this.decodedChanges.length)
+        .map(decodeChangeAndParseMetadata);
+      this.decodedChanges = this.decodedChanges.concat(newDecodedChanges);
+      const markers = getMarkersForDoc(this.handle, this.repo);
+
+      const { items, memoizedGroups } = getChangelogItems({
+        doc: this.handle.docSync(),
+        changes: this.decodedChanges,
+        options: { ...this.groupingOptions, markers },
+        memoizedGroups: this.memoizedGroups,
+      });
+      this.items = items;
+      this.memoizedGroups = memoizedGroups;
+      this.emit("change", this.items);
+    }
+  }
+
+  public teardown() {
+    this.handle.off("change", this.debouncedListener);
+    this.items = [];
+  }
+}
+
+// NOTE: this should be pushed down the stack as we formalize
+// support for structured metadata on changes.
+const decodeChangeAndParseMetadata = (change: A.Change) => {
+  let decodedChange = A.decodeChange(change) as DecodedChangeWithMetadata;
+  decodedChange.metadata = {};
+  try {
+    const metadata = JSON.parse(decodedChange.message);
+    decodedChange = { ...decodedChange, metadata };
+  } catch (e) {
+    // do nothing for now...
+  }
+  return decodedChange;
+};

--- a/src/patchwork/components/DiscussionInput.tsx
+++ b/src/patchwork/components/DiscussionInput.tsx
@@ -106,9 +106,7 @@ export const DiscussionInput = function <
             ?.heads
         )
       )
-    : JSON.parse(
-        JSON.stringify(changelogItems[changelogItems.length - 1]?.heads)
-      );
+    : A.getHeads(doc);
 
   const createDiscussion = () => {
     if (commentBoxContent === "") {

--- a/src/tee/datatype.ts
+++ b/src/tee/datatype.ts
@@ -61,16 +61,14 @@ export const getTitle = async (doc: MarkdownDoc) => {
   return `${title} ${subtitle && `: ${subtitle}`}`;
 };
 
-export const includeChangeInHistory = (
-  doc: MarkdownDoc,
-  decodedChange: DecodedChangeWithMetadata
-) => {
+export const includeChangeInHistory = (doc: MarkdownDoc) => {
   const contentObjID = A.getObjectId(doc, "content");
   const commentsObjID = A.getObjectId(doc, "commentThreads");
-
-  return decodedChange.ops.some(
-    (op) => op.obj === contentObjID || op.obj === commentsObjID
-  );
+  return (decodedChange: DecodedChangeWithMetadata) => {
+    return decodedChange.ops.some(
+      (op) => op.obj === contentObjID || op.obj === commentsObjID
+    );
+  };
 };
 
 export const includePatchInChangeGroup = (patch: A.Patch | TextPatch) =>

--- a/src/tldraw/datatype.ts
+++ b/src/tldraw/datatype.ts
@@ -44,10 +44,7 @@ export const getLLMSummary = (doc: TLDrawDoc) => {
 
 // We filter conservatively with a deny-list because dealing with edits on a nested schema is annoying.
 // Would be better to filter with an allow-list but that's tricky with current Automerge APIs.
-export const includeChangeInHistory = (
-  doc: TLDrawDoc,
-  decodedChange: DecodedChangeWithMetadata
-) => {
+export const includeChangeInHistory = (doc: TLDrawDoc) => {
   const metadataObjIds = [
     "branchMetadata",
     "tags",
@@ -56,7 +53,9 @@ export const includeChangeInHistory = (
     "changeGroupSummaries",
   ].map((path) => A.getObjectId(doc, path));
 
-  return decodedChange.ops.every((op) => !metadataObjIds.includes(op.obj));
+  return (decodedChange: DecodedChangeWithMetadata) => {
+    return decodedChange.ops.every((op) => !metadataObjIds.includes(op.obj));
+  };
 };
 
 export const patchesToAnnotations = (


### PR DESCRIPTION
## tldr

This PR makes typing in Patchwork while the timeline is open go from "unusably slow" to "reasonable".

## problem

Typing in Patchwork is really slow if you have the timeline open. The majority of the time is spent running `decodeChange` on every change in the log.

Here's an example trace of typing into a fairly challenging [test doc](http://patchwork.tee.inkandswitch.com/#docType=essay&docUrl=automerge%3A2s52ZZQvpq4A8hLYbqyYatE6mQu3), which is on the larger side for our usual docs but is not huge (~18k changes in history) -- each keystroke takes 700+ ms:

<img width="864" alt="CleanShot 2024-04-03 at 14 39 40@2x" src="https://github.com/inkandswitch/tiny-essay-editor/assets/934016/4bb88767-f392-48be-b23c-f0032d8a5570">

Most of the time is getting all changes from Automerge and decoding all of them.

Some of this stuff will move down into Automerge in the future so we don't want to over-invest in optimizing it. But it's also important to promote ongoing authentic use w/ reasonable perf.

## solution

This PR improves perf by ~15x, to ~50ms keystrokes w/ timeline open, on this test doc.

<img width="959" alt="CleanShot 2024-04-03 at 14 40 28@2x" src="https://github.com/inkandswitch/tiny-essay-editor/assets/934016/57a2572b-8e71-4347-922a-95c9c42a7909">

It achieves that by:

- don't re-decode all changes every time. cache the decoded changes we already have processed
- don't recompute all groups every time. if we're just appending to the end of the existing groups, handle that case incrementally. (we're fairly conservative here; we'll recompute groups in anything but the simplest case.)
- debounce updating the timeline to every 1 second during normal typing. (If a new milestone or comment is added, we have that reflected immediately.)

## testing

I did a bunch of manual testing with various docs and scenarios. This is the kind of thing where unit tests would help ensure reliability, but given that we want automerge to get better at incrementally maintaining change groupings long term, I'm not convinced that would be worth it in this case.

## future work

It looks like the most impactful next steps to improve this further would be to reduce time spent on React rendering. I suspect that this React time isn't being spent rendering the actual document, and is instead being spent rendering the patchwork sidebar, but I'm not sure...

![CleanShot 2024-04-03 at 14 51 31@2x](https://github.com/inkandswitch/tiny-essay-editor/assets/934016/e360c034-da5c-4305-9e55-68fe0e55c397)
