### PR TITLE
compute currentEditSessionDiff only once the branch picker is open

### DIFF
--- a/src/patchwork/components/PatchworkDocEditor.tsx
+++ b/src/patchwork/components/PatchworkDocEditor.tsx
@@ -118,6 +118,7 @@ export const PatchworkDocEditor: React.FC<{
 
   const [isHoveringYankToBranchOption, setIsHoveringYankToBranchOption] =
     useState(false);
+  const [isBranchPickerOpen, setIsBranchPickerOpen] = useState(false);
   const [showChangesFlag, setShowChangesFlag] = useState<boolean>(true);
   const [compareWithMainFlag, setCompareWithMainFlag] =
     useState<boolean>(false);
@@ -156,7 +157,7 @@ export const PatchworkDocEditor: React.FC<{
   }, [doc, sessionStartHeads]);
 
   const currentEditSessionDiff = useMemo(() => {
-    if (!doc || !sessionStartHeads) {
+    if (!doc || !sessionStartHeads || !isBranchPickerOpen) {
       return undefined;
     }
 
@@ -169,7 +170,7 @@ export const PatchworkDocEditor: React.FC<{
         diff.patches.filter((patch) => patch.path[0] === "content")
       ),
     };
-  }, [doc, sessionStartHeads]);
+  }, [doc, sessionStartHeads, isBranchPickerOpen]);
 
   const actorIdToAuthor = useActorIdToAuthorMap(mainDocUrl);
 
@@ -376,6 +377,7 @@ export const PatchworkDocEditor: React.FC<{
         <div className="bg-gray-100 pl-4 pt-3 pb-3 flex gap-2 items-center border-b border-gray-200">
           <Select
             value={JSON.stringify(selectedBranch)}
+            onOpenChange={setIsBranchPickerOpen}
             onValueChange={(value) => {
               if (value === "__newDraft") {
                 handleCreateBranch();

--- a/src/patchwork/components/PatchworkDocEditor.tsx
+++ b/src/patchwork/components/PatchworkDocEditor.tsx
@@ -118,7 +118,6 @@ export const PatchworkDocEditor: React.FC<{
 
   const [isHoveringYankToBranchOption, setIsHoveringYankToBranchOption] =
     useState(false);
-  const [isBranchPickerOpen, setIsBranchPickerOpen] = useState(false);
   const [showChangesFlag, setShowChangesFlag] = useState<boolean>(true);
   const [compareWithMainFlag, setCompareWithMainFlag] =
     useState<boolean>(false);
@@ -157,7 +156,7 @@ export const PatchworkDocEditor: React.FC<{
   }, [doc, sessionStartHeads]);
 
   const currentEditSessionDiff = useMemo(() => {
-    if (!doc || !sessionStartHeads || !isBranchPickerOpen) {
+    if (!doc || !sessionStartHeads || !isHoveringYankToBranchOption) {
       return undefined;
     }
 
@@ -170,7 +169,7 @@ export const PatchworkDocEditor: React.FC<{
         diff.patches.filter((patch) => patch.path[0] === "content")
       ),
     };
-  }, [doc, sessionStartHeads, isBranchPickerOpen]);
+  }, [doc, sessionStartHeads, isHoveringYankToBranchOption]);
 
   const actorIdToAuthor = useActorIdToAuthorMap(mainDocUrl);
 
@@ -377,7 +376,6 @@ export const PatchworkDocEditor: React.FC<{
         <div className="bg-gray-100 pl-4 pt-3 pb-3 flex gap-2 items-center border-b border-gray-200">
           <Select
             value={JSON.stringify(selectedBranch)}
-            onOpenChange={setIsBranchPickerOpen}
             onValueChange={(value) => {
               if (value === "__newDraft") {
                 handleCreateBranch();
@@ -468,23 +466,18 @@ export const PatchworkDocEditor: React.FC<{
                   <PlusIcon className="inline mr-1" size={12} />
                   Create new branch
                 </SelectItem>
-                {selectedBranch.type === "main" &&
-                  currentEditSessionDiff &&
-                  currentEditSessionDiff.patches.length > 0 && (
-                    <SelectItem
-                      value={"__moveChangesToBranch"}
-                      key={"__moveChangesToBranch"}
-                      className="font-regular"
-                      onMouseEnter={() => setIsHoveringYankToBranchOption(true)}
-                      onMouseLeave={() =>
-                        setIsHoveringYankToBranchOption(false)
-                      }
-                    >
-                      <SplitIcon className="inline mr-1" size={12} />
-                      Move my changes ({currentEditSessionDiff?.patches.length})
-                      to new Branch
-                    </SelectItem>
-                  )}
+                {selectedBranch.type === "main" && (
+                  <SelectItem
+                    value={"__moveChangesToBranch"}
+                    key={"__moveChangesToBranch"}
+                    className="font-regular"
+                    onMouseEnter={() => setIsHoveringYankToBranchOption(true)}
+                    onMouseLeave={() => setIsHoveringYankToBranchOption(false)}
+                  >
+                    <SplitIcon className="inline mr-1" size={12} />
+                    Move edits from this session to a new branch
+                  </SelectItem>
+                )}
               </SelectGroup>
             </SelectContent>
           </Select>


### PR DESCRIPTION
We recompute the diff of the current edit session every time the document changes. We only need that diff when the user interacts with the branch picker for moving the changes from the current edit session to a new branch. This patch computes the diff lazily only once the branch picker is opened.

Currently, the move changes to the branch are specific to TEE. We could only compute the edit session diff for doc types that support retroactive branching (or make it more general). I think the performance penalty for just computing it once the branch picker is open is not that big.

How to test it:
- draw a bunch of scribbles / make some edits
- select everything and paste it 10 times
- performance should be ok; if you reload the page that shouldn't make things smoother