### PR TITLE
re-establish message channel when service worker restarts

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -27,6 +27,17 @@ async function initializeRepo() {
 
 const repo = initializeRepo();
 
+function sendMessageToClients(message) {
+  clients.matchAll().then((clients) => {
+    clients.forEach((client) => {
+      client.postMessage(message);
+    });
+  });
+}
+
+// When the service worker restarts, tell all clients to re-establish the message channel
+sendMessageToClients({ type: "SERVICE_WORKER_RESTARTED" });
+
 // put it on the global context for interactive use
 repo.then((r) => {
   self.repo = r;
@@ -148,7 +159,7 @@ self.addEventListener("fetch", async (event) => {
     );
   }
   // disable caching for now
-  /* else if (  
+  /* else if (
     import.meta.env.PROD &&
     event.request.method === "GET" &&
     url.origin === self.location.origin

--- a/src/os/main.tsx
+++ b/src/os/main.tsx
@@ -87,6 +87,13 @@ navigator.serviceWorker.addEventListener("controllerchange", (event) => {
   }
 });
 
+// Re-establish the MessageChannel if the service worker restarts
+navigator.serviceWorker.addEventListener("message", (event) => {
+  if (event.data.type === "SERVICE_WORKER_RESTARTED") {
+    establishMessageChannel(serviceWorker);
+  }
+});
+
 // Connects the repo in the tab with the repo in the service worker through a message channel.
 // The repo in the tab takes advantage of loaded state in the SW.
 // TODO: clean up MessageChannels to old repos


### PR DESCRIPTION
Previously, if the service worker stopped and started again, existing tabs would never reconnect to it because the "controllerchange" event is not fired on restart.

This would lead to sync failures. (It may not be the only cause of recent sync issues, but it's one possibility, so we'll see if this fixes the problems we've been seeing.)
    
After this change, we have the service worker message all clients when it starts, to tell them to establish a new message channel.

## testing

Tested manually:

Before: if you manually stop and start the service worker, the tab gets desynced until reload
After: the tab does not get desynced

Also confirmed that only one message channel is established on initial pageload and we don't get extra.

One improvement would be to remove the existing network adapter, but automerge-repo doesn't have a way of doing that so I'm leaving it out of this PR