### PR TITLE
fix updating the description on a card that without a description

### DIFF
--- a/src/datatypes/kanban/datatype.ts
+++ b/src/datatypes/kanban/datatype.ts
@@ -182,6 +182,9 @@ const actions = {
       A.updateText(doc, ["cards", cardIndex, "title"], newCard.title);
     }
     if (newCard.description && newCard.description !== card.description) {
+      if (!card.description) {
+        card.description = "";
+      }
       A.updateText(
         doc,
         ["cards", cardIndex, "description"],


### PR DESCRIPTION
A.updateText() throws an error when you try to set the value on a field that hasn't been initialized. This led to a bug in Kanban where you couldn't set the description on cards created without a description. Now we initialize the description before we call update text.  