### PR TITLE
Allow to toggle on and off experimental data types

### DIFF
--- a/src/datatypes/bot/datatype.ts
+++ b/src/datatypes/bot/datatype.ts
@@ -15,6 +15,7 @@ export const EssayEditingBotDatatype: DataType<
 > = {
   id: "bot",
   name: "Bot",
+  isExperimental: true,
   icon: Bot,
   init: (doc: any, repo: Repo) => {
     const contactHandle = repo.create<RegisteredContactDoc>();

--- a/src/datatypes/datagrid/datatype.ts
+++ b/src/datatypes/datagrid/datatype.ts
@@ -130,6 +130,7 @@ export const DataGridDatatype: DataType<
 > = {
   id: "datagrid",
   name: "Spreadsheet",
+  isExperimental: true,
   icon: Sheet,
   init,
   getTitle,

--- a/src/datatypes/kanban/datatype.ts
+++ b/src/datatypes/kanban/datatype.ts
@@ -247,6 +247,7 @@ export const KanbanBoardDatatype: DataType<
 > = {
   id: "kanban",
   name: "Kanban Board",
+  isExperimental: true,
   icon: KanbanSquare,
   init,
   getTitle,

--- a/src/os/datatypes.ts
+++ b/src/os/datatypes.ts
@@ -28,6 +28,10 @@ export type CoreDataType<D> = {
   setTitle?: (doc: any, title: string) => void;
   markCopy: (doc: D) => void; // TODO: this shouldn't be part of the interface
   actions?: Record<string, (doc: Doc<D>, args: object) => void>;
+
+  /* Marking a data types as experimental hides it by default
+   * so the user has to enable them in their account first  */
+  isExperimental?: boolean;
 };
 
 export type VersionedDataType<D, T, V> = {

--- a/src/os/explorer/account.ts
+++ b/src/os/explorer/account.ts
@@ -315,6 +315,15 @@ export function useSelf(): ContactDoc {
   return contactDoc;
 }
 
+export const useDatatypeSettings = (): DatatypeSettingsDoc => {
+  const [accountDoc] = useCurrentAccountDoc();
+  const [datatypeSettingsDoc] = useDocument<DatatypeSettingsDoc>(
+    accountDoc?.datatypeSettingsUrl
+  );
+
+  return datatypeSettingsDoc;
+};
+
 // Helpers to convert an automerge URL to/from an Account Token that the user can
 // paste in to login on another device.
 // The doc ID is the only part of the URL actually used by the system,

--- a/src/os/explorer/account.ts
+++ b/src/os/explorer/account.ts
@@ -15,11 +15,17 @@ import { useForceUpdate } from "@/components/utils";
 
 import { FolderDoc } from "@/datatypes/folder";
 import { useFolderDocWithChildren } from "../../datatypes/folder/hooks/useFolderDocWithChildren";
+import { DatatypeId } from "../datatypes";
+
+export type DatatypeSettingsDoc = {
+  enabledDatatypeIds: { [id: DatatypeId]: boolean };
+};
 
 export interface AccountDoc {
   contactUrl: AutomergeUrl;
   rootFolderUrl: AutomergeUrl;
   uiStateUrl: AutomergeUrl;
+  datatypeSettingsUrl: AutomergeUrl;
 }
 
 export type UIStateDoc = {
@@ -261,7 +267,17 @@ export function useCurrentAccount(): Account | undefined {
         account.uiStateUrl = uiStateHandle.url;
       });
     }
-  }, [account?.handle.docSync(), repo]);
+
+    if (doc && doc.datatypeSettingsUrl === undefined) {
+      const datatypeSettingsHandle = repo.create<DatatypeSettingsDoc>();
+      datatypeSettingsHandle.change((settings) => {
+        settings.enabledDatatypeIds = {};
+      });
+      account.handle.change((account) => {
+        account.datatypeSettingsUrl = datatypeSettingsHandle.url;
+      });
+    }
+  }, [account?.handle.docSync()]);
 
   return account;
 }

--- a/src/os/explorer/components/AccountPicker.tsx
+++ b/src/os/explorer/components/AccountPicker.tsx
@@ -328,7 +328,10 @@ export const AccountPicker = ({
                 {datatypeSettingsDoc &&
                   experimentalDatatypes.map((datatype) => {
                     return (
-                      <div className="flex items-center gap-2">
+                      <div
+                        className="flex items-center gap-2"
+                        key={datatype.id}
+                      >
                         <Checkbox
                           id={`datatype-${datatype.id}`}
                           checked={

--- a/src/os/explorer/components/Sidebar.tsx
+++ b/src/os/explorer/components/Sidebar.tsx
@@ -32,6 +32,7 @@ import { FolderDocWithMetadata } from "@/datatypes/folder/hooks/useFolderDocWith
 import { capitalize, uniqBy } from "lodash";
 import { HasVersionControlMetadata } from "@/os/versionControl/schema";
 import { UIStateDoc, useCurrentAccountDoc } from "../account";
+import { useDatatypeSettings } from "../account";
 
 const Node = (props: NodeRendererProps<DocLinkWithFolderPath>) => {
   const { node, style, dragHandle } = props;
@@ -160,6 +161,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
     rootFolderUrl,
     flatDocLinks,
   } = rootFolderDoc;
+
+  const datatypeSettings = useDatatypeSettings();
 
   // state related to open popover
   const [openNewDocPopoverVisible, setOpenNewDocPopoverVisible] =
@@ -324,21 +327,30 @@ export const Sidebar: React.FC<SidebarProps> = ({
         </div>
       </div>
       <div className="py-2  border-b border-gray-200">
-        {Object.entries(DATA_TYPES).map(([id, datatype]) => (
-          <div key={datatype.id}>
-            {" "}
-            <div
-              className="py-1 px-2 text-sm text-gray-600 cursor-pointer hover:bg-gray-200 "
-              onClick={() => addNewDocument({ type: id as DatatypeId })}
-            >
-              <datatype.icon
-                size={14}
-                className="inline-block font-bold mr-2 align-top mt-[2px]"
-              />
-              New {datatype.name}
+        {Object.entries(DATA_TYPES).map(([id, datatype]) => {
+          if (
+            datatype.isExperimental &&
+            !datatypeSettings?.enabledDatatypeIds[id]
+          ) {
+            return;
+          }
+
+          return (
+            <div key={datatype.id}>
+              {" "}
+              <div
+                className="py-1 px-2 text-sm text-gray-600 cursor-pointer hover:bg-gray-200 "
+                onClick={() => addNewDocument({ type: id as DatatypeId })}
+              >
+                <datatype.icon
+                  size={14}
+                  className="inline-block font-bold mr-2 align-top mt-[2px]"
+                />
+                New {datatype.name}
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
 
         <div
           className="py-1 px-2 text-sm text-gray-600 cursor-pointer hover:bg-gray-200 "

--- a/src/os/explorer/components/Topbar.tsx
+++ b/src/os/explorer/components/Topbar.tsx
@@ -42,7 +42,8 @@ import { DatatypeId, DATA_TYPES } from "../../datatypes";
 import { runBot } from "@/datatypes/bot/essayEditingBot";
 import { Button } from "@/components/ui/button";
 import { HasVersionControlMetadata } from "@/os/versionControl/schema";
-import { useRootFolderDocWithChildren } from "../account";
+import { useDatatypeSettings, useRootFolderDocWithChildren } from "../account";
+import botDataType from "@/datatypes/bot";
 
 type TopbarProps = {
   showSidebar: boolean;
@@ -68,6 +69,11 @@ export const Topbar: React.FC<TopbarProps> = ({
 }) => {
   const repo = useRepo();
   const { flatDocLinks } = useRootFolderDocWithChildren();
+
+  const datatypeSettings = useDatatypeSettings();
+  const isBotDatatypeEnabled =
+    datatypeSettings?.enabledDatatypeIds[botDataType.id];
+
   const selectedDocUrl = selectedDocLink?.url;
   const selectedDocName = selectedDocLink?.name;
   const selectedDocType = selectedDocLink?.type;
@@ -132,72 +138,74 @@ export const Topbar: React.FC<TopbarProps> = ({
        how do datatypes contribute things to the global topbar? */}
       {selectedDocLink?.type === "essay" && (
         <div className="ml-auto mr-4">
-          <DropdownMenu>
-            <DropdownMenuTrigger>
-              <Bot
-                size={18}
-                className="mt-1 mr-21 text-gray-500 hover:text-gray-800"
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent className="mr-4">
-              {botDocLinks.length === 0 && (
-                <div>
-                  <div className="text-gray-500 max-w-48 p-2">
-                    No bots in sidebar. <br />
-                    Click "New Bot" or get a share link from someone.
+          {isBotDatatypeEnabled && (
+            <DropdownMenu>
+              <DropdownMenuTrigger>
+                <Bot
+                  size={18}
+                  className="mt-1 mr-21 text-gray-500 hover:text-gray-800"
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="mr-4">
+                {botDocLinks.length === 0 && (
+                  <div>
+                    <div className="text-gray-500 max-w-48 p-2">
+                      No bots in sidebar. <br />
+                      Click "New Bot" or get a share link from someone.
+                    </div>
                   </div>
-                </div>
-              )}
-              {botDocLinks.map((botDocLink) => (
-                <DropdownMenuItem
-                  key={botDocLink.url}
-                  onClick={async () => {
-                    const resultPromise = runBot({
-                      botDocUrl: botDocLink.url,
-                      targetDocHandle:
-                        selectedDocHandle as DocHandle<MarkdownDoc>,
-                      repo,
-                    });
-                    toast.promise(resultPromise, {
-                      loading: `Running ${botDocLink.name}...`,
-                      success: (result) => (
-                        <div className="flex gap-1">
-                          <div className="flex items-center gap-2">
-                            <div className="max-w-48">
-                              {botDocLink.name} ran successfully.
-                            </div>
-                            <Button
-                              onClick={() => {
-                                // todo: add branch to doclink
-                                /* setSelectedBranch({
+                )}
+                {botDocLinks.map((botDocLink) => (
+                  <DropdownMenuItem
+                    key={botDocLink.url}
+                    onClick={async () => {
+                      const resultPromise = runBot({
+                        botDocUrl: botDocLink.url,
+                        targetDocHandle:
+                          selectedDocHandle as DocHandle<MarkdownDoc>,
+                        repo,
+                      });
+                      toast.promise(resultPromise, {
+                        loading: `Running ${botDocLink.name}...`,
+                        success: (result) => (
+                          <div className="flex gap-1">
+                            <div className="flex items-center gap-2">
+                              <div className="max-w-48">
+                                {botDocLink.name} ran successfully.
+                              </div>
+                              <Button
+                                onClick={() => {
+                                  // todo: add branch to doclink
+                                  /* setSelectedBranch({
                                   type: "branch",
                                   url: result,
                                 })*/
-                              }}
-                              className="px-4 h-6"
-                            >
-                              View branch
-                            </Button>
+                                }}
+                                className="px-4 h-6"
+                              >
+                                View branch
+                              </Button>
+                            </div>
                           </div>
-                        </div>
-                      ),
-                      error: `${botDocLink.name} failed, see console`,
-                    });
-                  }}
-                >
-                  Run {botDocLink.name}
-                  <EditIcon
-                    size={14}
-                    className="inline-block ml-2 cursor-pointer"
-                    onClick={(e) => {
-                      selectDocLink({ ...botDocLink, type: "essay" });
-                      e.stopPropagation();
+                        ),
+                        error: `${botDocLink.name} failed, see console`,
+                      });
                     }}
-                  />
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+                  >
+                    Run {botDocLink.name}
+                    <EditIcon
+                      size={14}
+                      className="inline-block ml-2 cursor-pointer"
+                      onClick={(e) => {
+                        selectDocLink({ ...botDocLink, type: "essay" });
+                        e.stopPropagation();
+                      }}
+                    />
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
         </div>
       )}
       <div className={`mr-4 ${selectedDocLink?.type !== "essay" && "ml-auto"}`}>


### PR DESCRIPTION
I've added a section to the account where the user can toggle experimental datatypes
<img width="451" alt="Screenshot 2024-05-15 at 13 22 58" src="https://github.com/inkandswitch/tiny-essay-editor/assets/650540/733bca8a-eadb-436e-9a68-3b293c191aee">


If you turn off a datatype, it removes the new document button for it. The bot button has some extra logic to hide the bot button in the essay editor if the bot datatype is disabled.