### PR TITLE
ping service worker from tab to keep it alive

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -56,6 +56,9 @@ self.addEventListener("install", () => {
 });
 
 self.addEventListener("message", async (event) => {
+  if (event.data.type === "PING") {
+    return;
+  }
   console.log(`${PEER_ID}: Client messaged`, event.data);
   if (event.data && event.data.type === "INIT_PORT") {
     const clientPort = event.ports[0];

--- a/src/os/main.tsx
+++ b/src/os/main.tsx
@@ -20,6 +20,13 @@ import "./index.css";
 
 const serviceWorker = await setupServiceWorker();
 
+// Service workers stop on their own, which breaks sync.
+// Here we ping the service worker while the tab is running
+// to keep it alive (and make it restart if it did stop.)
+setInterval(() => {
+  serviceWorker.postMessage({ type: "PING" });
+}, 5000);
+
 // This case should never happen
 // if the service worker is not defined here either the initialization failed
 // or we found a new case that we haven't considered yet
@@ -90,6 +97,7 @@ navigator.serviceWorker.addEventListener("controllerchange", (event) => {
 // Re-establish the MessageChannel if the service worker restarts
 navigator.serviceWorker.addEventListener("message", (event) => {
   if (event.data.type === "SERVICE_WORKER_RESTARTED") {
+    console.log("Service worker restarted, establishing message channel");
     establishMessageChannel(serviceWorker);
   }
 });


### PR DESCRIPTION
This morning I observed a tab in a state where sync was broken and the SW had stopped. Turns out, by default, service workers stop on their own, and we don't do anything in a client tab to restart the SW if it has stopped. (Sync messages are sent on a new message channel, not the original SW channel, which I guess seems not to cause the SW to restart?)

This change pings the SW with a message every 5 seconds which should cause it to stay alive. (based on this info that incoming messages cause the SW to start: https://stackoverflow.com/a/29750936)

It's difficult to test this change because the conditions that make a SW stop are not totally observable. I can say that running this patch I haven't seen a SW stop yet.

I think we should just push this to production and try using it for a couple days. Previously I was seeing very frequent (many times a day) sync failures, so if this fixes the issue it should be pretty obvious.