### PR TITLE
Fix incorrect deleted values in diff highlight

### DIFF
--- a/src/os/versionControl/components/TimelineSidebar.tsx
+++ b/src/os/versionControl/components/TimelineSidebar.tsx
@@ -508,7 +508,11 @@ const useChangelogSelection = function <T>({
       setDocHeads(undefined);
     }
 
-    const fromItem = items.find((item) => item.id === selection?.from);
+    const fromItemIndex = items.findIndex(
+      (item) => item.id === selection?.from
+    );
+    const previousItem = items[fromItemIndex - 1];
+    const fromItem = items[fromItemIndex];
     const toItem = items.find((item) => item.id === selection?.to);
     const fromIndex = items.findIndex((item) => item.id === selection?.from);
     const toIndex = items.findIndex((item) => item.id === selection?.to);
@@ -530,7 +534,11 @@ const useChangelogSelection = function <T>({
         }
       })
       .filter((patch) => patch !== undefined);
-    setDiff({ patches, fromHeads: fromItem.heads, toHeads: toItem.heads });
+    setDiff({
+      patches,
+      fromHeads: previousItem?.heads ?? [],
+      toHeads: toItem.heads,
+    });
   }, [selection, setDiff, setDocHeads, items]);
 
   const itemsContainerRef = useRef<HTMLDivElement>(null);

--- a/src/os/versionControl/components/VersionControlEditor.tsx
+++ b/src/os/versionControl/components/VersionControlEditor.tsx
@@ -124,13 +124,13 @@ export const VersionControlEditor: React.FC<{
 
   useEffect(() => {
     if (!isSidebarOpen) {
-      setDiffFromHistorySidebar(undefined);
-      setDocHeadsFromHistorySidebar(undefined);
+      setDiffFromTimelineSidebar(undefined);
+      setDocHeadsFromTimelineSidebar(undefined);
     }
   }, [isSidebarOpen]);
-  const [diffFromHistorySidebar, setDiffFromHistorySidebar] =
+  const [diffFromTimelineSidebar, setDiffFromTimelineSidebar] =
     useState<DiffWithProvenance>();
-  const [docHeadsFromHistorySidebar, setDocHeadsFromHistorySidebar] =
+  const [docHeadsFromTimelineSidebar, setDocHeadsFromTimelineSidebar] =
     useState<A.Heads>();
 
   useEffect(() => {
@@ -291,10 +291,15 @@ export const VersionControlEditor: React.FC<{
   }, [branchDoc]);
 
   const diffForEditor =
-    diffFromHistorySidebar ??
+    diffFromTimelineSidebar ??
     (showDiff ? branchDiff ?? currentEditSessionDiff : undefined);
 
-  const activeDoc = selectedBranch ? branchDoc : doc;
+  const docHeads = docHeadsFromTimelineSidebar ?? undefined;
+  const activeDoc = selectedBranch
+    ? branchDoc
+    : docHeads
+    ? A.view(doc, docHeads)
+    : doc;
   const activeChangeDoc = selectedBranch ? changeBranchDoc : changeDoc;
   const activeHandle = selectedBranch ? branchHandle : handle;
 
@@ -328,8 +333,6 @@ export const VersionControlEditor: React.FC<{
   // ---- ANYTHING RELYING ON doc SHOULD GO BELOW HERE ----
 
   const branches = doc.branchMetadata.branches ?? [];
-
-  const docHeads = docHeadsFromHistorySidebar ?? undefined;
 
   return (
     <div className="flex h-full overflow-hidden">
@@ -599,8 +602,8 @@ export const VersionControlEditor: React.FC<{
                 key={selectedBranch?.url ?? mainDocUrl}
                 datatypeId={datatypeId}
                 docUrl={selectedBranch?.url ?? mainDocUrl}
-                setDocHeads={setDocHeadsFromHistorySidebar}
-                setDiff={setDiffFromHistorySidebar}
+                setDocHeads={setDocHeadsFromTimelineSidebar}
+                setDiff={setDiffFromTimelineSidebar}
                 selectedBranch={selectedBranch}
                 setSelectedBranch={setSelectedBranch}
               />

--- a/src/os/versionControl/schema.ts
+++ b/src/os/versionControl/schema.ts
@@ -55,8 +55,8 @@ export type Diffable = {
 // where they came from
 export type DiffWithProvenance = {
   patches: (A.Patch | TextPatch)[];
-  fromHeads: A.Heads;
-  toHeads: A.Heads;
+  fromHeads: A.Heads; // heads of the doc before the patches
+  toHeads: A.Heads; // heads of the doc after the patches
 };
 
 export type DiscussionComment = {

--- a/src/os/versionControl/schema.ts
+++ b/src/os/versionControl/schema.ts
@@ -55,8 +55,10 @@ export type Diffable = {
 // where they came from
 export type DiffWithProvenance = {
   patches: (A.Patch | TextPatch)[];
-  fromHeads: A.Heads; // heads of the doc before the patches
-  toHeads: A.Heads; // heads of the doc after the patches
+  /** The heads of the doc before the patches */
+  fromHeads: A.Heads;
+  /** The heads of the doc after the patches */
+  toHeads: A.Heads;
 };
 
 export type DiscussionComment = {


### PR DESCRIPTION
When diffing previous versions in the timeline sidebar the diff annotations in the editor would show wrong deleted values.

<img width="522" alt="Screenshot 2024-05-16 at 10 10 46" src="https://github.com/inkandswitch/tiny-essay-editor/assets/650540/7f77e305-33fd-4216-bc23-c3d4da3fba35">


The problem was that we didn't pass in the correct docBefore to the `patchesToAnnotation` function. This was caused by the useChangelogSelection which would set the fromHeads to the heads of the from item instead of the heads of the item before.