### PR TITLE
show diffs that start at beginning of doc

### DIFF
--- a/src/tools/essay/components/EssayEditor.tsx
+++ b/src/tools/essay/components/EssayEditor.tsx
@@ -55,7 +55,7 @@ export const EssayEditor = (props: EditorProps<MarkdownDocAnchor, string>) => {
       const fromPos = getCursorPositionSafely(doc, ["content"], fromCursor);
       const toPos = getCursorPositionSafely(doc, ["content"], toCursor);
 
-      return !fromPos || !toPos
+      return fromPos === undefined || toPos === undefined
         ? []
         : [
             {


### PR DESCRIPTION
If a diff started at the beginning of the doc, we were not showing the annotation in the doc, because of JS evaluating 0 as falsey