### PR TITLE
improvements to clickable links

### DIFF
--- a/src/os/explorer/hooks/useSelectedDocLink.tsx
+++ b/src/os/explorer/hooks/useSelectedDocLink.tsx
@@ -116,7 +116,7 @@ const parseLegacyUrl = (
   };
 };
 
-const parseUrl = (url: URL): Omit<DocLink, "name"> | null => {
+export const parseUrl = (url: URL): Omit<DocLink, "name"> | null => {
   const match = url.pathname.match(
     /^\/([a-z-A-Z0-9\-]+(\((?<branchName>[a-zA-Z0-9\-]+)\))?--)?(?<docId>\w+)$/
   );

--- a/src/tools/essay/codemirrorPlugins/clickableMarkdownLinks.tsx
+++ b/src/tools/essay/codemirrorPlugins/clickableMarkdownLinks.tsx
@@ -1,6 +1,10 @@
 import { syntaxTree } from "@codemirror/language";
 import { Decoration, EditorView, ViewPlugin } from "@codemirror/view";
 import { StateField, StateEffect } from "@codemirror/state";
+import {
+  parseUrl,
+  selectDocLink,
+} from "@/os/explorer/hooks/useSelectedDocLink";
 
 type Link = {
   url: string;
@@ -116,7 +120,19 @@ export const clickableMarkdownLinksPlugin = [
               return;
             }
 
-            window.open(link.url, "_tab");
+            // If it's an internal link starting with a /, try to route it internally within the app
+            const internalLinkMetadata =
+              link.url.startsWith("/") &&
+              parseUrl(new URL(`${location.origin}/${link.url.split("#")[1]}`));
+
+            if (internalLinkMetadata) {
+              selectDocLink({
+                ...internalLinkMetadata,
+                name: "Loading...",
+              });
+            } else {
+              window.open(link.url, "_tab");
+            }
           }
         },
 

--- a/src/tools/essay/codemirrorPlugins/clickableMarkdownLinks.tsx
+++ b/src/tools/essay/codemirrorPlugins/clickableMarkdownLinks.tsx
@@ -112,13 +112,11 @@ export const clickableMarkdownLinksPlugin = [
             event.stopPropagation();
             event.preventDefault();
 
-            if (link) {
-              if (event.shiftKey) {
-                window.open(link.url, "_tab");
-              } else {
-                window.location.href = link.url;
-              }
+            if (!link) {
+              return;
             }
+
+            window.open(link.url, "_tab");
           }
         },
 

--- a/src/tools/essay/codemirrorPlugins/clickableMarkdownLinks.tsx
+++ b/src/tools/essay/codemirrorPlugins/clickableMarkdownLinks.tsx
@@ -8,7 +8,7 @@ type Link = {
   to: number;
 };
 
-const URL_REGEX = /\[(?<url>[^\[]*)\]/;
+const URL_REGEX = /\[.*\]\((?<url>.*)\)/;
 
 const setHoveredLinkEffect = StateEffect.define<Link | undefined>();
 
@@ -59,7 +59,11 @@ function getLinks(view: EditorView): Link[] {
       enter: (node) => {
         if (node.name === "Link") {
           const link = view.state.sliceDoc(node.from, node.to);
-          const url = link.match(URL_REGEX).groups.url;
+          const url = link.match(URL_REGEX)?.groups?.url;
+
+          if (!url) {
+            return;
+          }
 
           links.push({
             from: node.from,


### PR DESCRIPTION
I found the clickable links feature not usable in practice so I fixed a few things.

Markdown syntax for links is `[title](url)`. The regex for clickable links wasn't capturing this correctly so I fixed it. Tested on a few docs and seems to work fine.

Also switched to always open in new tab, I think that's usually not the right default for a website but somehow that feels more right to me in this app. (One reason is that our first boot for patchwork is slow so I don't like losing the tab.)

I also added a new feature: a way to link between patchwork docs directly and route within the app. For now, the format is any patchwork url starting with the slash: `[link](/#title--<docid>)`. The reason I chose this instead of automerge URLs is that doc types and branch metadata are currently only in the patchwork URL and not the automerge URL.

https://github.com/inkandswitch/tiny-essay-editor/assets/934016/d3f418c2-5b39-4612-ac3a-f990c12b0eb4

